### PR TITLE
Enhance Test Cases to remove all the build warning

### DIFF
--- a/Tests/TUIkitTests/FrameDiffWriterTests.swift
+++ b/Tests/TUIkitTests/FrameDiffWriterTests.swift
@@ -191,8 +191,6 @@ struct DiffIntegrationTests {
 
     @Test("Content and status bar caches are independent")
     func independentCaches() {
-        let writer = FrameDiffWriter()
-
         // Simulate writing content + status bar (using internal state check)
         let contentLines = ["Content1", "Content2"]
         let statusLines = ["Status1"]

--- a/Tests/TUIkitTests/LifecycleManagerTests.swift
+++ b/Tests/TUIkitTests/LifecycleManagerTests.swift
@@ -218,12 +218,13 @@ struct LifecycleManagerTaskTests {
         nonisolated(unsafe) var wasCancelled = false
         manager.startTask(token: "task-1", priority: .medium) {
             // Long-running task that checks cancellation
-            try? await Task.sleep(for: .seconds(10))
+            try? await Task.sleep(for: .milliseconds(100))
             wasCancelled = Task.isCancelled
         }
         // Cancel immediately
         manager.cancelTask(token: "task-1")
         try await Task.sleep(for: .milliseconds(50))
+        #expect(wasCancelled == true)
         // Task was cancelled, so it either didn't complete the sleep
         // or Task.isCancelled was true. Either way the task is cancelled.
         // We can't easily observe the internal state, but cancellation was requested.

--- a/Tests/TUIkitTests/ProgressViewTests.swift
+++ b/Tests/TUIkitTests/ProgressViewTests.swift
@@ -198,7 +198,7 @@ struct ProgressViewStyleTests {
 
     @Test("All styles render correct width")
     func allStylesCorrectWidth() {
-        let styles: [ProgressBarStyle] = [.block, .blockFine, .shade, .bar, .dot]
+        let styles: [TrackStyle] = [.block, .blockFine, .shade, .bar, .dot]
         let context = testContext(width: 20)
 
         for style in styles {

--- a/Tests/TUIkitTests/RenderBottleneckTests.swift
+++ b/Tests/TUIkitTests/RenderBottleneckTests.swift
@@ -25,6 +25,7 @@ struct RenderBottleneckTests {
     /// Uses `Date` instead of `CFAbsoluteTimeGetCurrent` because CoreFoundation
     /// timing functions are not available on Linux. The precision difference
     /// is negligible for performance benchmarks at millisecond granularity.
+    @discardableResult
     private func measure(_ name: String, iterations: Int = 1000, block: () -> Void) -> TimeInterval {
         let start = Date()
         for _ in 0..<iterations {
@@ -53,19 +54,19 @@ struct RenderBottleneckTests {
 
         // Depth 2
         let depth2 = VStack { VStack { Text("A") } }
-        let time2 = measure("Depth 2", iterations: iterations) {
+        measure("Depth 2", iterations: iterations) {
             _ = renderToBuffer(depth2, context: context)
         }
 
         // Depth 3
         let depth3 = VStack { VStack { VStack { Text("A") } } }
-        let time3 = measure("Depth 3", iterations: iterations) {
+        measure("Depth 3", iterations: iterations) {
             _ = renderToBuffer(depth3, context: context)
         }
 
         // Depth 5
         let depth5 = VStack { VStack { VStack { VStack { VStack { Text("A") } } } } }
-        let time5 = measure("Depth 5", iterations: iterations) {
+        measure("Depth 5", iterations: iterations) {
             _ = renderToBuffer(depth5, context: context)
         }
 

--- a/Tests/TUIkitTests/SecureFieldTests.swift
+++ b/Tests/TUIkitTests/SecureFieldTests.swift
@@ -173,12 +173,9 @@ struct SecureFieldTests {
 
     @Test("SecureField onSubmit modifier stores action")
     func onSubmitStoresAction() {
-        var text = ""
-        var submitted = false
-        let binding = Binding(get: { text }, set: { text = $0 })
+        let binding = Binding(get: { "" }, set: { _ in })
 
-        let secureField = SecureField("Password", text: binding)
-            .onSubmit { submitted = true }
+        let secureField = SecureField("Password", text: binding).onSubmit {  }
 
         #expect(secureField.onSubmitAction != nil)
     }

--- a/Tests/TUIkitTests/StatePropertyTests.swift
+++ b/Tests/TUIkitTests/StatePropertyTests.swift
@@ -32,7 +32,6 @@ struct StatePropertyWrapperTests {
     func stateTriggerRender() {
         // StateBox.didSet calls AppState.shared.setNeedsRender().
         // We mutate and check that the shared instance is marked as needing render.
-        let initialNeedsRender = AppState.shared.needsRender
         let state = State(wrappedValue: "initial")
         state.wrappedValue = "changed"
         let triggered = AppState.shared.needsRender


### PR DESCRIPTION
## Summary

Building and running TUIkitTests currently flags 7 compiler warnings, cluttering the build logs. This PR cleans up the test target by:
- Resolving all 7 active warnings.
- Consolidating test logic.
- Enhancing a few test cases to add missing assertions

## Checklist

- [x] **Swift 6.0 compatible** (no features requiring a newer compiler)
- [x] **Builds on macOS and Linux** (`swift build` succeeds on both)
- [x] **All tests pass** (`swift test`)
- [x] **No new SwiftLint warnings** (`swiftlint`)
- [ ] Public APIs match SwiftUI signatures (parameter names, order, types)
- [ ] Modifiers propagate through the View hierarchy

## Test Plan
N/A
