### PR TITLE
Vim motion support

### DIFF
--- a/Sources/TUIkit/Environment/ViewEnvironmentKeys.swift
+++ b/Sources/TUIkit/Environment/ViewEnvironmentKeys.swift
@@ -60,3 +60,41 @@ extension EnvironmentValues {
         set { self[SelectionDisabledKey.self] = newValue }
     }
 }
+
+// MARK: - Vertical Navigation Styles Environment Key
+
+/// Environment key for vertical (up/down) keyboard navigation styles.
+private struct VerticalNavigationStylesKey: EnvironmentKey {
+    static let defaultValue: Set<VerticalNavigationStyle> = [.arrowKey]
+}
+
+extension EnvironmentValues {
+    /// The active vertical navigation styles for scrollable views.
+    ///
+    /// Controls which key bindings drive up/down movement in `List`, `Table`, and `Menu`.
+    /// Set via `.verticalNavigationStyle(_:)` modifier.
+    /// Default: `[.arrowKey]` (arrow keys only).
+    var verticalNavigationStyles: Set<VerticalNavigationStyle> {
+        get { self[VerticalNavigationStylesKey.self] }
+        set { self[VerticalNavigationStylesKey.self] = newValue }
+    }
+}
+
+// MARK: - Horizontal Navigation Styles Environment Key
+
+/// Environment key for horizontal (Tab/section) keyboard navigation styles.
+private struct HorizontalNavigationStylesKey: EnvironmentKey {
+    static let defaultValue: Set<HorizontalNavigationStyle> = [.tab]
+}
+
+extension EnvironmentValues {
+    /// The active horizontal navigation styles for cycling between focusable views.
+    ///
+    /// Controls which key bindings drive Tab-style focus cycling.
+    /// Set via `.horizontalNavigationStyle(_:)` modifier.
+    /// Default: `[.tab]` (Tab / Shift+Tab only).
+    var horizontalNavigationStyles: Set<HorizontalNavigationStyle> {
+        get { self[HorizontalNavigationStylesKey.self] }
+        set { self[HorizontalNavigationStylesKey.self] = newValue }
+    }
+}

--- a/Sources/TUIkit/Extensions/View+HorizontalNavigationStyle.swift
+++ b/Sources/TUIkit/Extensions/View+HorizontalNavigationStyle.swift
@@ -1,0 +1,36 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  View+HorizontalNavigationStyle.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+// MARK: - Horizontal Navigation Style Modifier
+
+extension View {
+    /// Sets the horizontal (Tab/section) keyboard navigation style for
+    /// focusable views in this subtree.
+    ///
+    /// Pass one or more styles to activate them simultaneously. Calling this
+    /// modifier replaces the inherited horizontal navigation style entirely.
+    ///
+    /// | Style | Keys |
+    /// |-------|------|
+    /// | `.tab` | Tab (next), Shift+Tab (previous) |
+    /// | `.vim` | l (next), h (previous) |
+    ///
+    /// ```swift
+    /// // Vim only — Tab inactive
+    /// VStack { … }
+    ///     .horizontalNavigationStyle(.vim)
+    ///
+    /// // Both — Tab and h/l all active
+    /// VStack { … }
+    ///     .horizontalNavigationStyle(.tab, .vim)
+    /// ```
+    ///
+    /// - Parameter styles: The horizontal navigation styles to activate.
+    /// - Returns: A view with the specified horizontal navigation styles applied.
+    public func horizontalNavigationStyle(_ styles: HorizontalNavigationStyle...) -> some View {
+        HorizontalNavigationStyleModifier(content: self, styles: Set(styles))
+    }
+}

--- a/Sources/TUIkit/Extensions/View+VerticalNavigationStyle.swift
+++ b/Sources/TUIkit/Extensions/View+VerticalNavigationStyle.swift
@@ -1,0 +1,36 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  View+VerticalNavigationStyle.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+// MARK: - Vertical Navigation Style Modifier
+
+extension View {
+    /// Sets the vertical (up/down) keyboard navigation style for scrollable
+    /// views in this subtree.
+    ///
+    /// Pass one or more styles to activate them simultaneously. Calling this
+    /// modifier replaces the inherited vertical navigation style entirely.
+    ///
+    /// | Style | Keys |
+    /// |-------|------|
+    /// | `.arrowKey` | ↑ ↓ Home End PageUp PageDown |
+    /// | `.vim` | j k g G Ctrl+d Ctrl+u Ctrl+f Ctrl+b |
+    ///
+    /// ```swift
+    /// // Vim only — arrow keys inactive
+    /// List("Items", selection: $sel) { … }
+    ///     .verticalNavigationStyle(.vim)
+    ///
+    /// // Both — all vertical keys active
+    /// List("Items", selection: $sel) { … }
+    ///     .verticalNavigationStyle(.vim, .arrowKey)
+    /// ```
+    ///
+    /// - Parameter styles: The vertical navigation styles to activate.
+    /// - Returns: A view with the specified vertical navigation styles applied.
+    public func verticalNavigationStyle(_ styles: VerticalNavigationStyle...) -> some View {
+        VerticalNavigationStyleModifier(content: self, styles: Set(styles))
+    }
+}

--- a/Sources/TUIkit/Focus/Focus.swift
+++ b/Sources/TUIkit/Focus/Focus.swift
@@ -60,6 +60,18 @@ public final class FocusManager: @unchecked Sendable {
     /// Callback triggered when focus changes (element or section).
     public var onFocusChange: (() -> Void)?
 
+    /// The active vertical (up/down) navigation styles for section-level navigation.
+    ///
+    /// Reset to `[.arrowKey]` each render pass, then updated by
+    /// `VerticalNavigationStyleModifier` during rendering.
+    var verticalNavigationStyles: Set<VerticalNavigationStyle> = [.arrowKey]
+
+    /// The active horizontal (Tab/section) navigation styles.
+    ///
+    /// Reset to `[.tab]` each render pass, then updated by
+    /// `HorizontalNavigationStyleModifier` during rendering.
+    var horizontalNavigationStyles: Set<HorizontalNavigationStyle> = [.tab]
+
     /// Creates a new focus manager instance.
     public init() {}
 
@@ -300,8 +312,11 @@ public extension FocusManager {
             }
         }
 
-        // Tab navigation: cycle sections (or elements within single section)
-        if event.key == .tab {
+        // Horizontal navigation: Tab/Shift+Tab and/or vim h/l cycle sections or elements.
+        let hasTab = horizontalNavigationStyles.contains(.tab)
+        let hasVimH = horizontalNavigationStyles.contains(.vim)
+
+        if event.key == .tab && hasTab {
             if event.shift {
                 focusPrevious()
             } else {
@@ -310,15 +325,23 @@ public extension FocusManager {
             return true
         }
 
-        // Arrow keys: navigate within the active section (fallback if element didn't handle)
-        // Up/Left go to previous, Down/Right go to next
+        // Vertical navigation: arrow keys and/or vim j/k navigate within the active section.
+        let hasArrow = verticalNavigationStyles.contains(.arrowKey)
+        let hasVimV = verticalNavigationStyles.contains(.vim)
+
         switch event.key {
         case .up, .left:
-            focusPreviousInSection()
-            return true
+            if hasArrow { focusPreviousInSection(); return true }
         case .down, .right:
-            focusNextInSection()
-            return true
+            if hasArrow { focusNextInSection(); return true }
+        case .character("k"):
+            if hasVimV { focusPreviousInSection(); return true }
+        case .character("j"):
+            if hasVimV { focusNextInSection(); return true }
+        case .character("h"):
+            if hasVimH { focusPrevious(); return true }
+        case .character("l"):
+            if hasVimH { focusNext(); return true }
         default:
             break
         }
@@ -407,6 +430,8 @@ extension FocusManager {
     /// Call this at the start of each render pass instead of ``clear()``.
     func beginRenderPass() {
         sections.removeAll()
+        verticalNavigationStyles = [.arrowKey]
+        horizontalNavigationStyles = [.tab]
         // activeSectionID and focusedID are intentionally preserved.
         // They will be validated after the render pass re-registers sections.
     }

--- a/Sources/TUIkit/Focus/HorizontalNavigationStyle.swift
+++ b/Sources/TUIkit/Focus/HorizontalNavigationStyle.swift
@@ -1,0 +1,33 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  HorizontalNavigationStyle.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+// MARK: - Horizontal Navigation Style
+
+/// The keyboard scheme for horizontal (Tab/section) navigation between focusable views.
+///
+/// Pass one or more styles to `.horizontalNavigationStyle(_:)` to control which
+/// key bindings cycle focus between interactive elements and sections. Styles
+/// combine freely — passing both enables all keys simultaneously.
+///
+/// ```swift
+/// // Tab only (default)
+/// VStack { … }
+///
+/// // Vim keys only (h = previous, l = next)
+/// VStack { … }
+///     .horizontalNavigationStyle(.vim)
+///
+/// // Both active together
+/// VStack { … }
+///     .horizontalNavigationStyle(.tab, .vim)
+/// ```
+public enum HorizontalNavigationStyle: Hashable, Sendable {
+    /// Standard Tab / Shift+Tab navigation: Tab = next, Shift+Tab = previous.
+    case tab
+
+    /// Vim-style horizontal keys: l = next (Tab), h = previous (Shift+Tab).
+    case vim
+}

--- a/Sources/TUIkit/Focus/ItemListHandler.swift
+++ b/Sources/TUIkit/Focus/ItemListHandler.swift
@@ -69,6 +69,9 @@ final class ItemListHandler<SelectionValue: Hashable>: Focusable {
     /// Whether this element can currently receive focus.
     var canBeFocused: Bool
 
+    /// The active keyboard navigation styles.
+    var verticalNavigationStyles: Set<VerticalNavigationStyle> = [.arrowKey]
+
     /// The currently focused item index (keyboard cursor).
     var focusedIndex: Int = 0
 
@@ -152,43 +155,63 @@ extension ItemListHandler {
     func handleKeyEvent(_ event: KeyEvent) -> Bool {
         guard itemCount > 0 else { return false }
 
+        let hasArrow = verticalNavigationStyles.contains(.arrowKey)
+        let hasVim = verticalNavigationStyles.contains(.vim)
+
         switch event.key {
-        case .up:
+
+        // Arrow key navigation
+        case .up where hasArrow:
             moveFocus(by: -1, wrap: true)
             return true
 
-        case .down:
+        case .down where hasArrow:
             moveFocus(by: 1, wrap: true)
             return true
 
-        case .home:
-            if selectableIndices.isEmpty {
-                focusedIndex = 0
-            } else if let firstSelectable = selectableIndices.min() {
-                focusedIndex = firstSelectable
-            } else {
-                return false
-            }
-            ensureFocusedItemVisible()
-            return true
+        case .home where hasArrow:
+            return jumpToFirst()
 
-        case .end:
-            if selectableIndices.isEmpty {
-                focusedIndex = itemCount - 1
-            } else if let lastSelectable = selectableIndices.max() {
-                focusedIndex = lastSelectable
-            } else {
-                return false
-            }
-            ensureFocusedItemVisible()
-            return true
+        case .end where hasArrow:
+            return jumpToLast()
 
-        case .pageUp:
+        case .pageUp where hasArrow:
             moveFocus(by: -viewportHeight, wrap: false)
             return true
 
-        case .pageDown:
+        case .pageDown where hasArrow:
             moveFocus(by: viewportHeight, wrap: false)
+            return true
+
+        // Vim motions
+        case .character("j") where hasVim:
+            moveFocus(by: 1, wrap: true)
+            return true
+
+        case .character("k") where hasVim:
+            moveFocus(by: -1, wrap: true)
+            return true
+
+        case .character("g") where hasVim:
+            return jumpToFirst()
+
+        case .character("G") where hasVim:
+            return jumpToLast()
+
+        case .character("d") where event.ctrl && hasVim:
+            moveFocus(by: max(1, viewportHeight / 2), wrap: false)
+            return true
+
+        case .character("u") where event.ctrl && hasVim:
+            moveFocus(by: -max(1, viewportHeight / 2), wrap: false)
+            return true
+
+        case .character("f") where event.ctrl && hasVim:
+            moveFocus(by: viewportHeight, wrap: false)
+            return true
+
+        case .character("b") where event.ctrl && hasVim:
+            moveFocus(by: -viewportHeight, wrap: false)
             return true
 
         case .enter, .space:
@@ -198,6 +221,34 @@ extension ItemListHandler {
         default:
             return false
         }
+    }
+
+    // MARK: - Jump Helpers
+
+    @discardableResult
+    private func jumpToFirst() -> Bool {
+        if selectableIndices.isEmpty {
+            focusedIndex = 0
+        } else if let firstSelectable = selectableIndices.min() {
+            focusedIndex = firstSelectable
+        } else {
+            return false
+        }
+        ensureFocusedItemVisible()
+        return true
+    }
+
+    @discardableResult
+    private func jumpToLast() -> Bool {
+        if selectableIndices.isEmpty {
+            focusedIndex = itemCount - 1
+        } else if let lastSelectable = selectableIndices.max() {
+            focusedIndex = lastSelectable
+        } else {
+            return false
+        }
+        ensureFocusedItemVisible()
+        return true
     }
 }
 

--- a/Sources/TUIkit/Focus/VerticalNavigationStyle.swift
+++ b/Sources/TUIkit/Focus/VerticalNavigationStyle.swift
@@ -1,0 +1,34 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  VerticalNavigationStyle.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+// MARK: - Vertical Navigation Style
+
+/// The keyboard scheme for vertical (up/down) navigation within scrollable views.
+///
+/// Pass one or more styles to `.verticalNavigationStyle(_:)` to control which
+/// key bindings drive up/down movement inside `List`, `Table`, `Menu`, and
+/// any other container that responds to up/down keys. Styles combine freely —
+/// passing both enables all keys simultaneously.
+///
+/// ```swift
+/// // Arrow keys only (default)
+/// List("Items", selection: $sel) { … }
+///
+/// // Vim keys only
+/// List("Items", selection: $sel) { … }
+///     .verticalNavigationStyle(.vim)
+///
+/// // Both active together
+/// List("Items", selection: $sel) { … }
+///     .verticalNavigationStyle(.vim, .arrowKey)
+/// ```
+public enum VerticalNavigationStyle: Hashable, Sendable {
+    /// Standard arrow-key navigation: ↑ ↓ Home End PageUp PageDown.
+    case arrowKey
+
+    /// Vim-style motion keys: j k g G Ctrl+d Ctrl+u Ctrl+f Ctrl+b.
+    case vim
+}

--- a/Sources/TUIkit/Modifiers/HorizontalNavigationStyleModifier.swift
+++ b/Sources/TUIkit/Modifiers/HorizontalNavigationStyleModifier.swift
@@ -1,0 +1,44 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  HorizontalNavigationStyleModifier.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+/// A modifier that sets the horizontal (Tab/section) keyboard navigation style
+/// for focusable views in this subtree.
+///
+/// Applied via `.horizontalNavigationStyle(_:)` on any view.
+public struct HorizontalNavigationStyleModifier<Content: View>: View {
+    /// The content to wrap.
+    let content: Content
+
+    /// The active horizontal navigation styles.
+    let styles: Set<HorizontalNavigationStyle>
+
+    public var body: Never {
+        fatalError("HorizontalNavigationStyleModifier renders via Renderable")
+    }
+}
+
+// MARK: - Equatable
+
+extension HorizontalNavigationStyleModifier: @preconcurrency Equatable where Content: Equatable {
+    public static func == (
+        lhs: HorizontalNavigationStyleModifier<Content>,
+        rhs: HorizontalNavigationStyleModifier<Content>
+    ) -> Bool {
+        lhs.content == rhs.content && lhs.styles == rhs.styles
+    }
+}
+
+// MARK: - Renderable
+
+extension HorizontalNavigationStyleModifier: Renderable {
+    public func renderToBuffer(context: RenderContext) -> FrameBuffer {
+        let modifiedEnvironment = context.environment.setting(\.horizontalNavigationStyles, to: styles)
+        let modifiedContext = context.withEnvironment(modifiedEnvironment)
+        // Propagate to FocusManager so Tab and vim h/l are gated correctly.
+        context.environment.focusManager.horizontalNavigationStyles = styles
+        return TUIkit.renderToBuffer(content, context: modifiedContext)
+    }
+}

--- a/Sources/TUIkit/Modifiers/VerticalNavigationStyleModifier.swift
+++ b/Sources/TUIkit/Modifiers/VerticalNavigationStyleModifier.swift
@@ -1,0 +1,44 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  VerticalNavigationStyleModifier.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+/// A modifier that sets the vertical (up/down) keyboard navigation style
+/// for scrollable views in this subtree.
+///
+/// Applied via `.verticalNavigationStyle(_:)` on any view.
+public struct VerticalNavigationStyleModifier<Content: View>: View {
+    /// The content to wrap.
+    let content: Content
+
+    /// The active vertical navigation styles.
+    let styles: Set<VerticalNavigationStyle>
+
+    public var body: Never {
+        fatalError("VerticalNavigationStyleModifier renders via Renderable")
+    }
+}
+
+// MARK: - Equatable
+
+extension VerticalNavigationStyleModifier: @preconcurrency Equatable where Content: Equatable {
+    public static func == (
+        lhs: VerticalNavigationStyleModifier<Content>,
+        rhs: VerticalNavigationStyleModifier<Content>
+    ) -> Bool {
+        lhs.content == rhs.content && lhs.styles == rhs.styles
+    }
+}
+
+// MARK: - Renderable
+
+extension VerticalNavigationStyleModifier: Renderable {
+    public func renderToBuffer(context: RenderContext) -> FrameBuffer {
+        let modifiedEnvironment = context.environment.setting(\.verticalNavigationStyles, to: styles)
+        let modifiedContext = context.withEnvironment(modifiedEnvironment)
+        // Propagate to FocusManager for section-level fallback navigation (VStack, etc.).
+        context.environment.focusManager.verticalNavigationStyles = styles
+        return TUIkit.renderToBuffer(content, context: modifiedContext)
+    }
+}

--- a/Sources/TUIkit/Views/Menu.swift
+++ b/Sources/TUIkit/Views/Menu.swift
@@ -293,36 +293,53 @@ private struct _MenuCore: View, Renderable {
         let itemCount = items.count
         let menuItems = items
         let selectCallback = onSelect
+        let navStyles = context.environment.verticalNavigationStyles
+        let hasArrow = navStyles.contains(.arrowKey)
+        let hasVim = navStyles.contains(.vim)
 
         context.environment.keyEventDispatcher!.addHandler { event in
             switch event.key {
             case .up:
-                // Move selection up
+                guard hasArrow else { return false }
                 let current = binding.wrappedValue
-                if current > 0 {
-                    binding.wrappedValue = current - 1
-                } else {
-                    binding.wrappedValue = itemCount - 1  // Wrap to bottom
-                }
+                binding.wrappedValue = current > 0 ? current - 1 : itemCount - 1
                 return true
 
             case .down:
-                // Move selection down
+                guard hasArrow else { return false }
                 let current = binding.wrappedValue
-                if current < itemCount - 1 {
-                    binding.wrappedValue = current + 1
-                } else {
-                    binding.wrappedValue = 0  // Wrap to top
-                }
+                binding.wrappedValue = current < itemCount - 1 ? current + 1 : 0
+                return true
+
+            case .character("k"):
+                guard hasVim else { return false }
+                let current = binding.wrappedValue
+                binding.wrappedValue = current > 0 ? current - 1 : itemCount - 1
+                return true
+
+            case .character("j"):
+                guard hasVim else { return false }
+                let current = binding.wrappedValue
+                binding.wrappedValue = current < itemCount - 1 ? current + 1 : 0
+                return true
+
+            case .character("g"):
+                guard hasVim else { return false }
+                binding.wrappedValue = 0
+                return true
+
+            case .character("G"):
+                guard hasVim else { return false }
+                binding.wrappedValue = itemCount - 1
                 return true
 
             case .enter:
-                // Select current item
                 selectCallback?(binding.wrappedValue)
                 return true
 
             case .character(let character):
-                // Check for shortcut
+                // Shortcut jump — vim j/k/g/G are already handled above so they
+                // won't reach here when vim mode is active.
                 for (index, item) in menuItems.enumerated() {
                     if let shortcut = item.shortcut,
                         shortcut.lowercased() == character.lowercased()

--- a/Sources/TUIkit/Views/Table.swift
+++ b/Sources/TUIkit/Views/Table.swift
@@ -240,6 +240,7 @@ private struct _TableCore<Value: Identifiable & Sendable>: View, Renderable wher
             handler.itemCount = data.count
             handler.viewportHeight = viewportHeight
             handler.canBeFocused = !isDisabled
+            handler.verticalNavigationStyles = context.environment.verticalNavigationStyles
             handler.itemIDs = data.map { $0.id }
 
             // Assign selection bindings directly (type-safe, no AnyHashable conversion)

--- a/Sources/TUIkit/Views/_ListCore.swift
+++ b/Sources/TUIkit/Views/_ListCore.swift
@@ -69,6 +69,7 @@ struct _ListCore<SelectionValue: Hashable & Sendable, Content: View, Footer: Vie
             handler.itemCount = rows.count
             handler.viewportHeight = viewportHeight
             handler.canBeFocused = !isDisabled
+            handler.verticalNavigationStyles = context.environment.verticalNavigationStyles
 
             // Build selectableIndices set and itemIDs from typed rows
             var selectableIndices = Set<Int>()

--- a/Sources/TUIkitExample/main.swift
+++ b/Sources/TUIkitExample/main.swift
@@ -16,6 +16,8 @@ struct ExampleApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .horizontalNavigationStyle(.tab, .vim)
+                .verticalNavigationStyle(.arrowKey, .vim)
         }
     }
 }

--- a/Tests/TUIkitTests/FocusManagerTests.swift
+++ b/Tests/TUIkitTests/FocusManagerTests.swift
@@ -336,3 +336,269 @@ struct FocusManagerEnvironmentTests {
         #expect(manager2.currentFocusedID == "test-2")
     }
 }
+
+// MARK: - Focus Manager Vertical Vim Navigation Tests
+
+@MainActor
+@Suite("FocusManager Vertical Vim Navigation Tests")
+struct FocusManagerVerticalVimTests {
+
+    @Test("Default style — j/k are not consumed")
+    func defaultStyleIgnoresJK() {
+        let manager = FocusManager()
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+        // verticalNavigationStyles defaults to [.arrowKey]
+
+        let jHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("j")))
+        let kHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("k")))
+
+        #expect(jHandled == false)
+        #expect(kHandled == false)
+        #expect(manager.isFocused(e1))  // Focus unchanged
+    }
+
+    @Test("Vertical vim — j moves focus to next element in section")
+    func jMovesToNextInSection() {
+        let manager = FocusManager()
+        manager.verticalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let handled = manager.dispatchKeyEvent(KeyEvent(key: .character("j")))
+
+        #expect(handled == true)
+        #expect(manager.isFocused(e2))
+    }
+
+    @Test("Vertical vim — k moves focus to previous element in section")
+    func kMovesToPreviousInSection() {
+        let manager = FocusManager()
+        manager.verticalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+        manager.focus(e2)
+
+        let handled = manager.dispatchKeyEvent(KeyEvent(key: .character("k")))
+
+        #expect(handled == true)
+        #expect(manager.isFocused(e1))
+    }
+
+    @Test("Vertical vim only — arrow keys are not consumed as section navigation")
+    func vimOnlyArrowKeysNotConsumedByFallback() {
+        let manager = FocusManager()
+        manager.verticalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a", shouldConsumeEvents: false)
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        // .down should not be handled by the fallback when arrowKey style is absent
+        let downHandled = manager.dispatchKeyEvent(KeyEvent(key: .down))
+
+        #expect(downHandled == false)
+        #expect(manager.isFocused(e1))  // Focus not changed
+    }
+
+    @Test("Both vertical styles — j and down arrow both navigate")
+    func bothVerticalStylesWork() {
+        let manager = FocusManager()
+        manager.verticalNavigationStyles = [.arrowKey, .vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        let e3 = MockFocusable(id: "c")
+        manager.register(e1)
+        manager.register(e2)
+        manager.register(e3)
+
+        let downHandled = manager.dispatchKeyEvent(KeyEvent(key: .down))
+        #expect(downHandled == true)
+        #expect(manager.isFocused(e2))
+
+        let jHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("j")))
+        #expect(jHandled == true)
+        #expect(manager.isFocused(e3))
+    }
+
+    @Test("beginRenderPass resets vertical styles to arrowKey default")
+    func beginRenderPassResetsVerticalStyles() {
+        let manager = FocusManager()
+        manager.verticalNavigationStyles = [.vim]
+
+        manager.beginRenderPass()
+
+        // After reset, vim keys should not be consumed
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let jHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("j")))
+        #expect(jHandled == false)
+
+        // Arrow keys should work again
+        let downHandled = manager.dispatchKeyEvent(KeyEvent(key: .down))
+        #expect(downHandled == true)
+    }
+}
+
+// MARK: - Focus Manager Horizontal Vim Navigation Tests
+
+@MainActor
+@Suite("FocusManager Horizontal Vim Navigation Tests")
+struct FocusManagerHorizontalVimTests {
+
+    @Test("Default style — h/l are not consumed")
+    func defaultStyleIgnoresHL() {
+        let manager = FocusManager()
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+        // horizontalNavigationStyles defaults to [.tab]
+
+        let lHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("l")))
+        let hHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("h")))
+
+        #expect(lHandled == false)
+        #expect(hHandled == false)
+        #expect(manager.isFocused(e1))  // Focus unchanged
+    }
+
+    @Test("Horizontal vim — l cycles to next focusable")
+    func lCyclesToNext() {
+        let manager = FocusManager()
+        manager.horizontalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let handled = manager.dispatchKeyEvent(KeyEvent(key: .character("l")))
+
+        #expect(handled == true)
+        #expect(manager.isFocused(e2))
+    }
+
+    @Test("Horizontal vim — h cycles to previous focusable")
+    func hCyclesToPrevious() {
+        let manager = FocusManager()
+        manager.horizontalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+        manager.focus(e2)
+
+        let handled = manager.dispatchKeyEvent(KeyEvent(key: .character("h")))
+
+        #expect(handled == true)
+        #expect(manager.isFocused(e1))
+    }
+
+    @Test("Horizontal vim only — Tab is not consumed")
+    func vimOnlyTabNotConsumed() {
+        let manager = FocusManager()
+        manager.horizontalNavigationStyles = [.vim]
+
+        let e1 = MockFocusable(id: "a", shouldConsumeEvents: false)
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let tabHandled = manager.dispatchKeyEvent(KeyEvent(key: .tab))
+
+        #expect(tabHandled == false)
+        #expect(manager.isFocused(e1))  // Focus not changed by Tab
+    }
+
+    @Test("Tab only — l/h are not consumed")
+    func tabOnlyIgnoresHL() {
+        let manager = FocusManager()
+        // horizontalNavigationStyles defaults to [.tab]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let lHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("l")))
+        #expect(lHandled == false)
+        #expect(manager.isFocused(e1))
+    }
+
+    @Test("Tab only — Tab still cycles focus")
+    func tabOnlyTabWorks() {
+        let manager = FocusManager()
+        // horizontalNavigationStyles defaults to [.tab]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let handled = manager.dispatchKeyEvent(KeyEvent(key: .tab))
+
+        #expect(handled == true)
+        #expect(manager.isFocused(e2))
+    }
+
+    @Test("Both horizontal styles — Tab and h/l all cycle focus")
+    func bothHorizontalStylesWork() {
+        let manager = FocusManager()
+        manager.horizontalNavigationStyles = [.tab, .vim]
+
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        let e3 = MockFocusable(id: "c")
+        manager.register(e1)
+        manager.register(e2)
+        manager.register(e3)
+
+        let tabHandled = manager.dispatchKeyEvent(KeyEvent(key: .tab))
+        #expect(tabHandled == true)
+        #expect(manager.isFocused(e2))
+
+        let lHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("l")))
+        #expect(lHandled == true)
+        #expect(manager.isFocused(e3))
+
+        let hHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("h")))
+        #expect(hHandled == true)
+        #expect(manager.isFocused(e2))
+    }
+
+    @Test("beginRenderPass resets horizontal styles to tab default")
+    func beginRenderPassResetsHorizontalStyles() {
+        let manager = FocusManager()
+        manager.horizontalNavigationStyles = [.vim]
+
+        manager.beginRenderPass()
+
+        // After reset, vim h/l should not be consumed
+        let e1 = MockFocusable(id: "a")
+        let e2 = MockFocusable(id: "b")
+        manager.register(e1)
+        manager.register(e2)
+
+        let lHandled = manager.dispatchKeyEvent(KeyEvent(key: .character("l")))
+        #expect(lHandled == false)
+
+        // Tab should work again
+        let tabHandled = manager.dispatchKeyEvent(KeyEvent(key: .tab))
+        #expect(tabHandled == true)
+    }
+}

--- a/Tests/TUIkitTests/ItemListHandlerTests.swift
+++ b/Tests/TUIkitTests/ItemListHandlerTests.swift
@@ -447,3 +447,298 @@ struct ItemListHandlerScrollTests {
         #expect(range == 0..<5)
     }
 }
+
+// MARK: - Item List Handler Vim Motion Tests
+
+@MainActor
+@Suite("ItemListHandler Vim Motion Tests")
+struct ItemListHandlerVimMotionTests {
+
+    // Helper that creates a handler with vim vertical navigation active.
+    func makeVimHandler(itemCount: Int, viewportHeight: Int) -> ItemListHandler<String> {
+        let handler = ItemListHandler<String>(
+            focusID: "test",
+            itemCount: itemCount,
+            viewportHeight: viewportHeight,
+            selectionMode: .single
+        )
+        handler.verticalNavigationStyles = [.vim]
+        return handler
+    }
+
+    // MARK: j / k
+
+    @Test("j moves focus down")
+    func jMovesDown() {
+        let handler = makeVimHandler(itemCount: 5, viewportHeight: 5)
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("j")))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 1)
+    }
+
+    @Test("j wraps to start when at last item")
+    func jWrapsToStart() {
+        let handler = makeVimHandler(itemCount: 3, viewportHeight: 3)
+        handler.focusedIndex = 2
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("j")))
+
+        #expect(handler.focusedIndex == 0)
+    }
+
+    @Test("k moves focus up")
+    func kMovesUp() {
+        let handler = makeVimHandler(itemCount: 5, viewportHeight: 5)
+        handler.focusedIndex = 3
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("k")))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 2)
+    }
+
+    @Test("k wraps to end when at first item")
+    func kWrapsToEnd() {
+        let handler = makeVimHandler(itemCount: 3, viewportHeight: 3)
+        handler.focusedIndex = 0
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("k")))
+
+        #expect(handler.focusedIndex == 2)
+    }
+
+    // MARK: g / G
+
+    @Test("g jumps to first item")
+    func gJumpsToFirst() {
+        let handler = makeVimHandler(itemCount: 10, viewportHeight: 5)
+        handler.focusedIndex = 7
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("g")))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 0)
+    }
+
+    @Test("G jumps to last item")
+    func bigGJumpsToLast() {
+        let handler = makeVimHandler(itemCount: 10, viewportHeight: 5)
+        handler.focusedIndex = 2
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("G")))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 9)
+    }
+
+    @Test("g respects selectableIndices — jumps to first selectable")
+    func gRespectsSelectableIndices() {
+        let handler = makeVimHandler(itemCount: 5, viewportHeight: 5)
+        handler.selectableIndices = [1, 2, 3, 4]  // index 0 is a section header
+        handler.focusedIndex = 3
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("g")))
+
+        #expect(handler.focusedIndex == 1)
+    }
+
+    @Test("G respects selectableIndices — jumps to last selectable")
+    func bigGRespectsSelectableIndices() {
+        let handler = makeVimHandler(itemCount: 5, viewportHeight: 5)
+        handler.selectableIndices = [0, 1, 2, 3]  // index 4 is a section footer
+        handler.focusedIndex = 1
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("G")))
+
+        #expect(handler.focusedIndex == 3)
+    }
+
+    // MARK: Ctrl+d / Ctrl+u (half page)
+
+    @Test("Ctrl+d moves half a viewport down")
+    func ctrlDHalfPageDown() {
+        let handler = makeVimHandler(itemCount: 20, viewportHeight: 6)
+        handler.focusedIndex = 2
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("d"), ctrl: true))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 5)  // 2 + max(1, 6/2) = 2 + 3
+    }
+
+    @Test("Ctrl+u moves half a viewport up")
+    func ctrlUHalfPageUp() {
+        let handler = makeVimHandler(itemCount: 20, viewportHeight: 6)
+        handler.focusedIndex = 8
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("u"), ctrl: true))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 5)  // 8 - max(1, 6/2) = 8 - 3
+    }
+
+    @Test("Ctrl+d clamps at last item")
+    func ctrlDClampsAtEnd() {
+        let handler = makeVimHandler(itemCount: 10, viewportHeight: 6)
+        handler.focusedIndex = 8  // 8 + 3 = 11, clamped to 9
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("d"), ctrl: true))
+
+        #expect(handler.focusedIndex == 9)
+    }
+
+    @Test("Ctrl+u clamps at first item")
+    func ctrlUClampsAtStart() {
+        let handler = makeVimHandler(itemCount: 10, viewportHeight: 6)
+        handler.focusedIndex = 1  // 1 - 3 = -2, clamped to 0
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("u"), ctrl: true))
+
+        #expect(handler.focusedIndex == 0)
+    }
+
+    @Test("Ctrl+d moves at least 1 step when viewport is 1")
+    func ctrlDMinimumStep() {
+        let handler = makeVimHandler(itemCount: 10, viewportHeight: 1)
+        handler.focusedIndex = 0
+
+        _ = handler.handleKeyEvent(KeyEvent(key: .character("d"), ctrl: true))
+
+        #expect(handler.focusedIndex == 1)  // max(1, 1/2) = 1
+    }
+
+    // MARK: Ctrl+f / Ctrl+b (full page)
+
+    @Test("Ctrl+f moves a full viewport down")
+    func ctrlFFullPageDown() {
+        let handler = makeVimHandler(itemCount: 20, viewportHeight: 5)
+        handler.focusedIndex = 2
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("f"), ctrl: true))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 7)  // 2 + 5
+    }
+
+    @Test("Ctrl+b moves a full viewport up")
+    func ctrlBFullPageUp() {
+        let handler = makeVimHandler(itemCount: 20, viewportHeight: 5)
+        handler.focusedIndex = 10
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .character("b"), ctrl: true))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 5)  // 10 - 5
+    }
+}
+
+// MARK: - Item List Handler Navigation Style Gating Tests
+
+@MainActor
+@Suite("ItemListHandler Navigation Style Gating Tests")
+struct ItemListHandlerNavigationStyleGatingTests {
+
+    @Test("Default style is arrowKey — j/k are ignored")
+    func defaultStyleIgnoresVimKeys() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 5, viewportHeight: 5, selectionMode: .single
+        )
+        // verticalNavigationStyles defaults to [.arrowKey]
+
+        let jHandled = handler.handleKeyEvent(KeyEvent(key: .character("j")))
+        let kHandled = handler.handleKeyEvent(KeyEvent(key: .character("k")))
+
+        #expect(jHandled == false)
+        #expect(kHandled == false)
+        #expect(handler.focusedIndex == 0)  // Unchanged
+    }
+
+    @Test("Default style is arrowKey — arrow keys still work")
+    func defaultStyleArrowKeysWork() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 5, viewportHeight: 5, selectionMode: .single
+        )
+
+        let handled = handler.handleKeyEvent(KeyEvent(key: .down))
+
+        #expect(handled == true)
+        #expect(handler.focusedIndex == 1)
+    }
+
+    @Test("Vim-only style — j moves focus, arrow keys are ignored")
+    func vimOnlyStyleArrowKeysIgnored() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 5, viewportHeight: 5, selectionMode: .single
+        )
+        handler.verticalNavigationStyles = [.vim]
+
+        let downHandled = handler.handleKeyEvent(KeyEvent(key: .down))
+        let homeHandled = handler.handleKeyEvent(KeyEvent(key: .home))
+        let pageDownHandled = handler.handleKeyEvent(KeyEvent(key: .pageDown))
+
+        #expect(downHandled == false)
+        #expect(homeHandled == false)
+        #expect(pageDownHandled == false)
+        #expect(handler.focusedIndex == 0)  // Unchanged by arrow keys
+    }
+
+    @Test("Vim-only style — j/k/g/G all work")
+    func vimOnlyStyleVimKeysWork() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 5, viewportHeight: 5, selectionMode: .single
+        )
+        handler.verticalNavigationStyles = [.vim]
+
+        let jHandled = handler.handleKeyEvent(KeyEvent(key: .character("j")))
+        #expect(jHandled == true)
+        #expect(handler.focusedIndex == 1)
+
+        let bigGHandled = handler.handleKeyEvent(KeyEvent(key: .character("G")))
+        #expect(bigGHandled == true)
+        #expect(handler.focusedIndex == 4)
+
+        let gHandled = handler.handleKeyEvent(KeyEvent(key: .character("g")))
+        #expect(gHandled == true)
+        #expect(handler.focusedIndex == 0)
+    }
+
+    @Test("Both styles — arrow keys and vim keys all work")
+    func bothStylesAllKeysWork() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 10, viewportHeight: 5, selectionMode: .single
+        )
+        handler.verticalNavigationStyles = [.arrowKey, .vim]
+
+        let downHandled = handler.handleKeyEvent(KeyEvent(key: .down))
+        #expect(downHandled == true)
+        #expect(handler.focusedIndex == 1)
+
+        let jHandled = handler.handleKeyEvent(KeyEvent(key: .character("j")))
+        #expect(jHandled == true)
+        #expect(handler.focusedIndex == 2)
+
+        let homeHandled = handler.handleKeyEvent(KeyEvent(key: .home))
+        #expect(homeHandled == true)
+        #expect(handler.focusedIndex == 0)
+
+        let gHandled = handler.handleKeyEvent(KeyEvent(key: .character("G")))
+        #expect(gHandled == true)
+        #expect(handler.focusedIndex == 9)
+    }
+
+    @Test("Empty style set — all navigation keys ignored")
+    func emptyStyleIgnoresAll() {
+        let handler = ItemListHandler<String>(
+            focusID: "test", itemCount: 5, viewportHeight: 5, selectionMode: .single
+        )
+        handler.verticalNavigationStyles = []
+
+        #expect(handler.handleKeyEvent(KeyEvent(key: .down)) == false)
+        #expect(handler.handleKeyEvent(KeyEvent(key: .character("j"))) == false)
+        #expect(handler.handleKeyEvent(KeyEvent(key: .home)) == false)
+        #expect(handler.handleKeyEvent(KeyEvent(key: .character("g"))) == false)
+        #expect(handler.focusedIndex == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in vim-style keyboard navigation to all interactive views in TUIkit, alongside a complementary horizontal navigation modifier.

### What changed

New public API — two composable modifiers:

```swift
// Vertical (up/down within a list, menu, or VStack)
.verticalNavigationStyle(.vim)
.verticalNavigationStyle(.vim, .arrowKey)   // both active

// Horizontal (Tab-cycling between sections/panels)
.horizontalNavigationStyle(.vim)
.horizontalNavigationStyle(.tab, .vim)      // both active
```

Both modifiers accept a variadic Set of styles, so each scheme is fully opt-in and can be combined freely. Neither changes the default behaviour. Existing apps get [.arrowKey] vertical and [.tab] horizontal with **zero migration required**.

## Checklist

- [x] **Swift 6.0 compatible** (no features requiring a newer compiler)
- [x] **Builds on macOS and Linux** (`swift build` succeeds on both)
- [x] **All tests pass** (`swift test`)
- [x] **No new SwiftLint warnings** (`swiftlint`)
- [x] Public APIs match SwiftUI signatures (parameter names, order, types)
- [x] Modifiers propagate through the View hierarchy

## Test Plan

35 new tests across 4 new suites in 2 existing test files

> Tests/TUIkitTests/ItemListHandlerTests.swift:

ItemListHandlerVimMotionTests (15 tests) — unit tests for every vim binding directly on ItemListHandler:
  - j moves down and wraps at the end
  - k moves up and wraps at the start
  - g jumps to index 0; respects selectableIndices (jumps to first selectable)
  - G jumps to last index; respects selectableIndices
  - Ctrl+d moves max(1, viewportHeight/2) forward, clamps at last item, moves at least 1 step even when viewport height is 1
  - Ctrl+u moves half page backward, clamps at first item
  - Ctrl+f moves a full page forward
  - Ctrl+b moves a full page backward
- ItemListHandlerNavigationStyleGatingTests (5 tests) — verifies the opt-in/opt-out gating:
  - Default [.arrowKey]: j/k return false and don't move the cursor
  - [.vim] only: .down/.home/.pageDown return false; vim keys work
  - [.arrowKey, .vim]: both sets work simultaneously
  - [] empty set: all navigation keys return false

> Tests/TUIkitTests/FocusManagerTests.swift:

FocusManagerVerticalVimTests (5 tests) — covers j/k in FocusManager.dispatchKeyEvent:
  - Default style: j/k not consumed by the fallback
  - [.vim]: j calls focusNextInSection, k calls focusPreviousInSection
  - [.vim] only: .down arrow not consumed by the fallback
  - [.arrowKey, .vim]: both key sets drive section navigation
  - beginRenderPass() resets verticalNavigationStyles back to [.arrowKey]

FocusManagerHorizontalVimTests (8 tests) — covers h/l and Tab gating:
  - Default [.tab]: h/l not consumed, Tab cycles focus
  - [.vim] only: l → focusNext, h → focusPrevious; Tab returns false
  - [.tab] only: l/h not consumed
  - [.tab, .vim]: Tab, l, and h all cycle focus correctly
  - beginRenderPass() resets horizontalNavigationStyles back to [.tab]

