### PR TITLE
Refactor: Introduce per-app render runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ TUIkit includes comprehensive i18n support with 5 languages and type-safe string
 import TUIkit
 
 struct MyView: View {
+    @Environment(\.localizationService) private var localization
+
     var body: some View {
         VStack {
             // Type-safe localized strings
@@ -196,7 +198,7 @@ struct MyView: View {
 
             // Switch language at runtime
             Button("Deutsch") {
-                AppState.shared.setLanguage(.german)
+                localization.setLanguage(.german)
             }
         }
     }

--- a/Sources/TUIkit/App/App.swift
+++ b/Sources/TUIkit/App/App.swift
@@ -86,8 +86,9 @@ internal final class AppRunner<A: App> {
     private var signals = SignalManager()
 
     init(app: A) {
+        let tuiContext = TUIContext()
         self.app = app
-        self.appState = AppState()
+        self.appState = tuiContext.appState
         self.appearanceManager = ThemeManager(items: AppearanceRegistry.all, renderTrigger: { [appState] in appState.setNeedsRender() })
         self.appHeader = AppHeaderState()
         self.focusManager = FocusManager()
@@ -95,7 +96,7 @@ internal final class AppRunner<A: App> {
         self.statusBar = StatusBarState(appState: appState)
         self.statusBar.style = .bordered
         self.terminal = Terminal()
-        self.tuiContext = TUIContext()
+        self.tuiContext = tuiContext
     }
 }
 

--- a/Sources/TUIkit/App/App.swift
+++ b/Sources/TUIkit/App/App.swift
@@ -86,14 +86,14 @@ internal final class AppRunner<A: App> {
     private var signals = SignalManager()
 
     init(app: A) {
-        let tuiContext = TUIContext()
+        let tuiContext = TUIContext.production()
         self.app = app
         self.appState = tuiContext.appState
-        self.appearanceManager = ThemeManager(items: AppearanceRegistry.all, renderTrigger: { [appState] in appState.setNeedsRender() })
-        self.appHeader = AppHeaderState()
-        self.focusManager = FocusManager()
-        self.paletteManager = ThemeManager(items: PaletteRegistry.all, renderTrigger: { [appState] in appState.setNeedsRender() })
-        self.statusBar = StatusBarState(appState: appState)
+        self.appearanceManager = tuiContext.appearanceManager
+        self.appHeader = tuiContext.appHeader
+        self.focusManager = tuiContext.focusManager
+        self.paletteManager = tuiContext.paletteManager
+        self.statusBar = tuiContext.statusBar
         self.statusBar.style = .bordered
         self.terminal = Terminal()
         self.tuiContext = tuiContext
@@ -140,9 +140,10 @@ extension AppRunner {
         }
 
         // Reset pulse animation and trigger re-render when focus changes
-        focusManager.onFocusChange = { [weak pulseTimer, weak appState] in
+        let runtimeFocusChangeHandler = focusManager.onFocusChange
+        focusManager.onFocusChange = { [weak pulseTimer] in
             pulseTimer?.reset()
-            appState?.setNeedsRender()
+            runtimeFocusChangeHandler?()
         }
 
         isRunning = true

--- a/Sources/TUIkit/App/App.swift
+++ b/Sources/TUIkit/App/App.swift
@@ -80,13 +80,17 @@ internal final class AppRunner<A: App> {
     private let focusManager: FocusManager
     private let paletteManager: ThemeManager
     private let statusBar: StatusBarState
-    private let terminal: Terminal
+    private let terminal: any TerminalProtocol
     private let tuiContext: TUIContext
     private var isRunning = false
     private var signals = SignalManager()
 
-    init(app: A) {
-        let tuiContext = TUIContext.production()
+    init(
+        app: A,
+        terminal: (any TerminalProtocol)? = nil,
+        tuiContext: TUIContext? = nil
+    ) {
+        let tuiContext = tuiContext ?? TUIContext.production()
         self.app = app
         self.appState = tuiContext.appState
         self.appearanceManager = tuiContext.appearanceManager
@@ -95,7 +99,7 @@ internal final class AppRunner<A: App> {
         self.paletteManager = tuiContext.paletteManager
         self.statusBar = tuiContext.statusBar
         self.statusBar.style = .bordered
-        self.terminal = Terminal()
+        self.terminal = terminal ?? Terminal()
         self.tuiContext = tuiContext
     }
 }

--- a/Sources/TUIkit/App/RenderLoop.swift
+++ b/Sources/TUIkit/App/RenderLoop.swift
@@ -276,30 +276,7 @@ extension RenderLoop {
     ///
     /// - Returns: A fully populated environment.
     func buildEnvironment() -> EnvironmentValues {
-        var environment = EnvironmentValues()
-        environment.statusBar = statusBar
-        environment.appHeader = appHeader
-        environment.focusManager = focusManager
-        environment.paletteManager = paletteManager
-        if let palette = paletteManager.currentPalette {
-            environment.palette = palette
-        }
-        environment.appearanceManager = appearanceManager
-        if let appearance = appearanceManager.currentAppearance {
-            environment.appearance = appearance
-        }
-        environment.notificationService = NotificationService.current
-
-        // Runtime services (previously accessed via context.tuiContext)
-        environment.stateStorage = tuiContext.stateStorage
-        environment.lifecycle = tuiContext.lifecycle
-        environment.keyEventDispatcher = tuiContext.keyEventDispatcher
-        environment.renderCache = tuiContext.renderCache
-        environment.renderInvalidationSink = tuiContext.appState
-        environment.preferenceStorage = tuiContext.preferences
-        environment.localizationService = LocalizationService.shared
-
-        return environment
+        tuiContext.environmentValues()
     }
 }
 

--- a/Sources/TUIkit/App/RenderLoop.swift
+++ b/Sources/TUIkit/App/RenderLoop.swift
@@ -186,9 +186,7 @@ extension RenderLoop {
 
         // If an @Published property changed, clear the entire render cache
         // so EquatableView-cached subtrees re-render with new model data.
-        if AppState.shared.consumeNeedsCacheClear() {
-            tuiContext.renderCache.clearAll()
-        }
+        tuiContext.applyPendingRenderInvalidations()
 
         // Terminal size: single getSize() call avoids 2 ioctl syscalls per frame.
         let terminalSize = terminal.getSize()
@@ -297,6 +295,7 @@ extension RenderLoop {
         environment.lifecycle = tuiContext.lifecycle
         environment.keyEventDispatcher = tuiContext.keyEventDispatcher
         environment.renderCache = tuiContext.renderCache
+        environment.renderInvalidationSink = tuiContext.appState
         environment.preferenceStorage = tuiContext.preferences
         environment.localizationService = LocalizationService.shared
 
@@ -329,7 +328,8 @@ private extension RenderLoop {
         let rootIdentity = ViewIdentity(rootType: A.self)
         StateRegistration.activeContext = HydrationContext(
             identity: rootIdentity,
-            storage: tuiContext.stateStorage
+            storage: tuiContext.stateStorage,
+            invalidationSink: tuiContext.appState
         )
         StateRegistration.counter = 0
         StateRegistration.activeEnvironment = environment

--- a/Sources/TUIkit/App/RenderLoop.swift
+++ b/Sources/TUIkit/App/RenderLoop.swift
@@ -109,7 +109,7 @@ internal final class RenderLoop<A: App> {
     let app: A
 
     /// The terminal for output and size queries.
-    let terminal: Terminal
+    let terminal: any TerminalProtocol
 
     /// The status bar state (height, items, appearance).
     let statusBar: StatusBarState
@@ -151,7 +151,7 @@ internal final class RenderLoop<A: App> {
 
     init(
         app: A,
-        terminal: Terminal,
+        terminal: any TerminalProtocol,
         statusBar: StatusBarState,
         appHeader: AppHeaderState,
         focusManager: FocusManager,
@@ -183,10 +183,6 @@ extension RenderLoop {
     ///   - cursorTimer: The cursor timer for TextField/SecureField animations.
     func render(pulsePhase: Double = 0, cursorTimer: CursorTimer? = nil) {
         beginRenderPass()
-
-        // If an @Published property changed, clear the entire render cache
-        // so EquatableView-cached subtrees re-render with new model data.
-        tuiContext.applyPendingRenderInvalidations()
 
         // Terminal size: single getSize() call avoids 2 ioctl syscalls per frame.
         let terminalSize = terminal.getSize()
@@ -285,15 +281,7 @@ extension RenderLoop {
 private extension RenderLoop {
     /// Clears all per-frame state and begins lifecycle/state/cache tracking.
     func beginRenderPass() {
-        tuiContext.keyEventDispatcher.clearHandlers()
-        tuiContext.preferences.beginRenderPass()
-        focusManager.beginRenderPass()
-        statusBar.clearSectionItems()
-        appHeader.beginRenderPass()
-        statusBar.focusManager = focusManager
-        tuiContext.lifecycle.beginRenderPass()
-        tuiContext.stateStorage.beginRenderPass()
-        tuiContext.renderCache.beginRenderPass()
+        tuiContext.beginRenderPass()
     }
 
     /// Evaluates `App.body` with hydration and environment context active.
@@ -380,10 +368,7 @@ private extension RenderLoop {
     /// Fires `onDisappear` for removed views and removes state/cache
     /// entries for views no longer in the tree.
     func endRenderPass() {
-        tuiContext.lifecycle.endRenderPass()
-        tuiContext.stateStorage.endRenderPass()
-        tuiContext.renderCache.removeInactive()
-        tuiContext.renderCache.logFrameStats()
+        tuiContext.endRenderPass()
     }
 
     /// Clears the render cache when environment values affecting visual output changed.

--- a/Sources/TUIkit/AppHeader/AppHeaderState.swift
+++ b/Sources/TUIkit/AppHeader/AppHeaderState.swift
@@ -90,7 +90,7 @@ extension AppHeaderState {
 
 /// Environment key for the app header state.
 private struct AppHeaderKey: EnvironmentKey {
-    static let defaultValue = AppHeaderState()
+    static var defaultValue: AppHeaderState { AppHeaderState() }
 }
 
 extension EnvironmentValues {

--- a/Sources/TUIkit/Environment/AppearanceEnvironment.swift
+++ b/Sources/TUIkit/Environment/AppearanceEnvironment.swift
@@ -41,7 +41,9 @@ extension EnvironmentValues {
 
 /// Environment key for the appearance manager.
 private struct AppearanceManagerKey: EnvironmentKey {
-    static let defaultValue = ThemeManager(items: AppearanceRegistry.all)
+    static var defaultValue: ThemeManager {
+        ThemeManager(items: AppearanceRegistry.all)
+    }
 }
 
 extension EnvironmentValues {

--- a/Sources/TUIkit/Environment/PaletteEnvironment.swift
+++ b/Sources/TUIkit/Environment/PaletteEnvironment.swift
@@ -41,7 +41,9 @@ extension EnvironmentValues {
 
 /// Environment key for the palette manager.
 private struct PaletteManagerKey: EnvironmentKey {
-    static let defaultValue = ThemeManager(items: PaletteRegistry.all)
+    static var defaultValue: ThemeManager {
+        ThemeManager(items: PaletteRegistry.all)
+    }
 }
 
 extension EnvironmentValues {

--- a/Sources/TUIkit/Environment/RenderContext+TUIContext.swift
+++ b/Sources/TUIkit/Environment/RenderContext+TUIContext.swift
@@ -33,6 +33,7 @@ extension RenderContext {
         env.lifecycle = tuiContext.lifecycle
         env.keyEventDispatcher = tuiContext.keyEventDispatcher
         env.renderCache = tuiContext.renderCache
+        env.renderInvalidationSink = tuiContext.appState
         env.preferenceStorage = tuiContext.preferences
         self.init(
             availableWidth: availableWidth,

--- a/Sources/TUIkit/Environment/RenderContext+TUIContext.swift
+++ b/Sources/TUIkit/Environment/RenderContext+TUIContext.swift
@@ -28,17 +28,13 @@ extension RenderContext {
         tuiContext: TUIContext,
         identity: ViewIdentity = ViewIdentity(path: "")
     ) {
-        var env = environment
-        env.stateStorage = tuiContext.stateStorage
-        env.lifecycle = tuiContext.lifecycle
-        env.keyEventDispatcher = tuiContext.keyEventDispatcher
-        env.renderCache = tuiContext.renderCache
-        env.renderInvalidationSink = tuiContext.appState
-        env.preferenceStorage = tuiContext.preferences
+        let environment = MainActor.assumeIsolated {
+            tuiContext.environmentValues(extending: environment)
+        }
         self.init(
             availableWidth: availableWidth,
             availableHeight: availableHeight,
-            environment: env,
+            environment: environment,
             identity: identity
         )
     }

--- a/Sources/TUIkit/Environment/RuntimeDependencies.swift
+++ b/Sources/TUIkit/Environment/RuntimeDependencies.swift
@@ -1,0 +1,66 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  RuntimeDependencies.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+import Foundation
+
+// MARK: - Runtime Clock
+
+/// Injectable wall clock used by time-based rendering services.
+struct RuntimeClock: Sendable {
+    /// System wall clock used by production runtimes.
+    static let system = Self {
+        Date().timeIntervalSinceReferenceDate
+    }
+
+    /// Provider returning seconds since the Foundation reference date.
+    private let nowProvider: @Sendable () -> TimeInterval
+
+    /// Creates a clock backed by the supplied provider.
+    init(now: @escaping @Sendable () -> TimeInterval) {
+        self.nowProvider = now
+    }
+
+    /// Returns the current wall-clock value.
+    func now() -> TimeInterval {
+        nowProvider()
+    }
+}
+
+// MARK: - Volatile Storage
+
+/// Process-local storage used by isolated and test runtimes.
+final class VolatileStorageBackend: StorageBackend, @unchecked Sendable {
+    /// Encoded values keyed by their application storage key.
+    private var values: [String: Data] = [:]
+
+    /// Lock protecting encoded values.
+    private let lock = NSLock()
+
+    /// Creates an empty volatile backend.
+    init() {}
+
+    func value<T: Codable>(forKey key: String) -> T? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = values[key] else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    func setValue<T: Codable>(_ value: T, forKey key: String) {
+        guard let data = try? JSONEncoder().encode(value) else { return }
+        lock.lock()
+        values[key] = data
+        lock.unlock()
+    }
+
+    func removeValue(forKey key: String) {
+        lock.lock()
+        values.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    func synchronize() {}
+}

--- a/Sources/TUIkit/Environment/ServiceEnvironment.swift
+++ b/Sources/TUIkit/Environment/ServiceEnvironment.swift
@@ -8,7 +8,21 @@
 
 /// EnvironmentKey for the localization service.
 private struct LocalizationServiceKey: EnvironmentKey {
-    static let defaultValue = LocalizationService.shared
+    static var defaultValue: LocalizationService { LocalizationService.transient() }
+}
+
+// MARK: - Runtime Clock
+
+/// EnvironmentKey for time-based runtime services.
+private struct RuntimeClockKey: EnvironmentKey {
+    static let defaultValue = RuntimeClock.system
+}
+
+// MARK: - Application Storage
+
+/// EnvironmentKey for the runtime-owned AppStorage backend.
+private struct StorageBackendKey: EnvironmentKey {
+    static var defaultValue: any StorageBackend { VolatileStorageBackend() }
 }
 
 // MARK: - Lifecycle Manager
@@ -65,14 +79,26 @@ private struct ActiveFocusSectionKey: EnvironmentKey {
 extension EnvironmentValues {
 
     /// The localization service for retrieving translated strings.
-    var localizationService: LocalizationService {
+    public var localizationService: LocalizationService {
         get { self[LocalizationServiceKey.self] }
         set { self[LocalizationServiceKey.self] = newValue }
     }
 
     /// The currently active language.
-    var currentLanguage: LocalizationService.Language {
+    public var currentLanguage: LocalizationService.Language {
         localizationService.currentLanguage
+    }
+
+    /// Clock used by time-based views and services in this runtime.
+    var runtimeClock: RuntimeClock {
+        get { self[RuntimeClockKey.self] }
+        set { self[RuntimeClockKey.self] = newValue }
+    }
+
+    /// Persistent storage backend owned by this runtime.
+    var storageBackend: any StorageBackend {
+        get { self[StorageBackendKey.self] }
+        set { self[StorageBackendKey.self] = newValue }
     }
 
     /// View lifecycle tracking (appear, disappear, task management).

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -204,6 +204,9 @@ extension LifecycleManager {
 /// ```
 final class TUIContext: @unchecked Sendable {
 
+    /// Thread-safe render state and invalidation sink owned by this runtime.
+    let appState: AppState
+
     /// View lifecycle tracking (appear, disappear, task management).
     let lifecycle: LifecycleManager
 
@@ -227,10 +230,12 @@ final class TUIContext: @unchecked Sendable {
     ///
     /// Each context owns an independent render cache.
     init() {
+        let appState = AppState()
+        self.appState = appState
         self.lifecycle = LifecycleManager()
         self.keyEventDispatcher = KeyEventDispatcher()
         self.preferences = PreferenceStorage()
-        self.stateStorage = StateStorage()
+        self.stateStorage = StateStorage(invalidationSink: appState)
         self.renderCache = RenderCache()
     }
 
@@ -242,28 +247,50 @@ final class TUIContext: @unchecked Sendable {
     ///   - lifecycle: The lifecycle manager to use.
     ///   - keyEventDispatcher: The key event dispatcher to use.
     ///   - preferences: The preference storage to use.
+    ///   - appState: The render state and invalidation sink to use.
     ///   - stateStorage: The state storage to use.
     ///   - renderCache: The render cache to use.
     init(
         lifecycle: LifecycleManager,
         keyEventDispatcher: KeyEventDispatcher,
         preferences: PreferenceStorage,
+        appState: AppState = AppState(),
         stateStorage: StateStorage = StateStorage(),
         renderCache: RenderCache = RenderCache()
     ) {
+        self.appState = appState
         self.lifecycle = lifecycle
         self.keyEventDispatcher = keyEventDispatcher
         self.preferences = preferences
         self.stateStorage = stateStorage
         self.renderCache = renderCache
+        stateStorage.setInvalidationSink(appState)
     }
 }
 
 // MARK: - Internal API
 
 extension TUIContext {
+    /// Applies cache invalidations queued by state producers.
+    ///
+    /// This method runs on the render owner before a frame, keeping the
+    /// non-thread-safe render cache away from background state tasks.
+    func applyPendingRenderInvalidations() {
+        for invalidation in appState.consumePendingCacheInvalidations() {
+            switch invalidation {
+            case .renderOnly:
+                break
+            case .subtree(let identity):
+                renderCache.clearAffected(by: identity)
+            case .all:
+                renderCache.clearAll()
+            }
+        }
+    }
+
     /// Resets all services to their initial state.
     func reset() {
+        appState.reset()
         lifecycle.reset()
         keyEventDispatcher.clearHandlers()
         preferences.reset()

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -254,6 +254,12 @@ final class TUIContext {
     /// Application header state owned by this runtime.
     let appHeader: AppHeaderState
 
+    /// Image loader used by this runtime.
+    let imageLoader: any ImageLoader
+
+    /// URL image cache owned by this runtime.
+    let imageCache: URLImageCache
+
     /// Creates a new TUI context with fresh instances of all services.
     ///
     /// Each context owns an independent render cache.
@@ -274,6 +280,8 @@ final class TUIContext {
     ///   - clock: Clock used by time-based services.
     ///   - focusManager: Focus state to use.
     ///   - appHeader: Application header state to use.
+    ///   - imageLoader: Loader for file and URL image requests.
+    ///   - imageCache: Cache for URL image results.
     nonisolated init(
         appState: AppState = AppState(),
         lifecycle: LifecycleManager = LifecycleManager(),
@@ -286,7 +294,9 @@ final class TUIContext {
         notificationService: NotificationService? = nil,
         clock: RuntimeClock = .system,
         focusManager: FocusManager = FocusManager(),
-        appHeader: AppHeaderState = AppHeaderState()
+        appHeader: AppHeaderState = AppHeaderState(),
+        imageLoader: any ImageLoader = PlatformImageLoader(),
+        imageCache: URLImageCache = URLImageCache()
     ) {
         let localizationService = localizationService ?? LocalizationService.transient()
         let notificationService = notificationService ?? NotificationService()
@@ -324,6 +334,8 @@ final class TUIContext {
         )
         self.statusBar = StatusBarState(appState: appState)
         self.appHeader = appHeader
+        self.imageLoader = imageLoader
+        self.imageCache = imageCache
     }
 }
 
@@ -358,6 +370,8 @@ extension TUIContext {
         environment.appearanceManager = appearanceManager
         environment.statusBar = statusBar
         environment.appHeader = appHeader
+        environment.imageLoader = imageLoader
+        environment.imageCache = imageCache
 
         if let palette = paletteManager.currentPalette {
             environment.palette = palette
@@ -395,6 +409,7 @@ extension TUIContext {
         renderCache.reset()
         notificationService.clear()
         focusManager.clear()
+        imageCache.removeAll()
         storageBackend.synchronize()
     }
 }

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -225,13 +225,13 @@ final class TUIContext: @unchecked Sendable {
 
     /// Creates a new TUI context with fresh instances of all services.
     ///
-    /// Uses the shared `RenderCache` singleton for all instances.
+    /// Each context owns an independent render cache.
     init() {
         self.lifecycle = LifecycleManager()
         self.keyEventDispatcher = KeyEventDispatcher()
         self.preferences = PreferenceStorage()
         self.stateStorage = StateStorage()
-        self.renderCache = RenderCache.shared
+        self.renderCache = RenderCache()
     }
 
     /// Creates a new TUI context with the given services.
@@ -243,13 +243,13 @@ final class TUIContext: @unchecked Sendable {
     ///   - keyEventDispatcher: The key event dispatcher to use.
     ///   - preferences: The preference storage to use.
     ///   - stateStorage: The state storage to use.
-    ///   - renderCache: The render cache to use (defaults to the shared singleton).
+    ///   - renderCache: The render cache to use.
     init(
         lifecycle: LifecycleManager,
         keyEventDispatcher: KeyEventDispatcher,
         preferences: PreferenceStorage,
         stateStorage: StateStorage = StateStorage(),
-        renderCache: RenderCache = RenderCache.shared
+        renderCache: RenderCache = RenderCache()
     ) {
         self.lifecycle = lifecycle
         self.keyEventDispatcher = keyEventDispatcher

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -202,7 +202,8 @@ extension LifecycleManager {
 ///     }
 /// }
 /// ```
-final class TUIContext: @unchecked Sendable {
+@MainActor
+final class TUIContext {
 
     /// Thread-safe render state and invalidation sink owned by this runtime.
     let appState: AppState
@@ -226,51 +227,147 @@ final class TUIContext: @unchecked Sendable {
     /// for removed views are garbage-collected at the end of each render pass.
     let renderCache: RenderCache
 
+    /// Localization state owned by this runtime.
+    let localizationService: LocalizationService
+
+    /// Notification queue owned by this runtime.
+    let notificationService: NotificationService
+
+    /// Persistent application storage owned by this runtime.
+    let storageBackend: StorageBackend
+
+    /// Clock used by time-based views and services.
+    let clock: RuntimeClock
+
+    /// Keyboard focus state owned by this runtime.
+    let focusManager: FocusManager
+
+    /// Color palette selection owned by this runtime.
+    let paletteManager: ThemeManager
+
+    /// Border appearance selection owned by this runtime.
+    let appearanceManager: ThemeManager
+
+    /// Status bar state owned by this runtime.
+    let statusBar: StatusBarState
+
+    /// Application header state owned by this runtime.
+    let appHeader: AppHeaderState
+
     /// Creates a new TUI context with fresh instances of all services.
     ///
     /// Each context owns an independent render cache.
-    init() {
-        let appState = AppState()
-        self.appState = appState
-        self.lifecycle = LifecycleManager()
-        self.keyEventDispatcher = KeyEventDispatcher()
-        self.preferences = PreferenceStorage()
-        self.stateStorage = StateStorage(invalidationSink: appState)
-        self.renderCache = RenderCache()
-    }
-
-    /// Creates a new TUI context with the given services.
+    /// Creates a new isolated TUI context with injectable services.
     ///
     /// Useful for testing where you want to inject mock services.
     ///
     /// - Parameters:
+    ///   - appState: The render state and invalidation sink to use.
     ///   - lifecycle: The lifecycle manager to use.
     ///   - keyEventDispatcher: The key event dispatcher to use.
     ///   - preferences: The preference storage to use.
-    ///   - appState: The render state and invalidation sink to use.
     ///   - stateStorage: The state storage to use.
     ///   - renderCache: The render cache to use.
-    init(
-        lifecycle: LifecycleManager,
-        keyEventDispatcher: KeyEventDispatcher,
-        preferences: PreferenceStorage,
+    ///   - storageBackend: The AppStorage backend to use.
+    ///   - localizationService: Optional localization service to adopt.
+    ///   - notificationService: Optional notification service to adopt.
+    ///   - clock: Clock used by time-based services.
+    ///   - focusManager: Focus state to use.
+    ///   - appHeader: Application header state to use.
+    nonisolated init(
         appState: AppState = AppState(),
+        lifecycle: LifecycleManager = LifecycleManager(),
+        keyEventDispatcher: KeyEventDispatcher = KeyEventDispatcher(),
+        preferences: PreferenceStorage = PreferenceStorage(),
         stateStorage: StateStorage = StateStorage(),
-        renderCache: RenderCache = RenderCache()
+        renderCache: RenderCache = RenderCache(),
+        storageBackend: StorageBackend = VolatileStorageBackend(),
+        localizationService: LocalizationService? = nil,
+        notificationService: NotificationService? = nil,
+        clock: RuntimeClock = .system,
+        focusManager: FocusManager = FocusManager(),
+        appHeader: AppHeaderState = AppHeaderState()
     ) {
+        let localizationService = localizationService ?? LocalizationService.transient()
+        let notificationService = notificationService ?? NotificationService()
+
+        localizationService.setInvalidationSink(appState)
+        notificationService.setRuntimeDependencies(
+            clock: clock,
+            invalidationSink: appState
+        )
+        stateStorage.setInvalidationSink(appState)
+        let existingFocusChangeHandler = focusManager.onFocusChange
+        focusManager.onFocusChange = { [appState] in
+            existingFocusChangeHandler?()
+            appState.setNeedsRender()
+        }
+
         self.appState = appState
         self.lifecycle = lifecycle
         self.keyEventDispatcher = keyEventDispatcher
         self.preferences = preferences
         self.stateStorage = stateStorage
         self.renderCache = renderCache
-        stateStorage.setInvalidationSink(appState)
+        self.localizationService = localizationService
+        self.notificationService = notificationService
+        self.storageBackend = storageBackend
+        self.clock = clock
+        self.focusManager = focusManager
+        self.paletteManager = ThemeManager(
+            items: PaletteRegistry.all,
+            renderTrigger: { [appState] in appState.setNeedsRender() }
+        )
+        self.appearanceManager = ThemeManager(
+            items: AppearanceRegistry.all,
+            renderTrigger: { [appState] in appState.setNeedsRender() }
+        )
+        self.statusBar = StatusBarState(appState: appState)
+        self.appHeader = appHeader
     }
 }
 
 // MARK: - Internal API
 
 extension TUIContext {
+    /// Creates a runtime backed by the user's persistent configuration.
+    static func production() -> TUIContext {
+        TUIContext(
+            storageBackend: StorageDefaults.runtimeBackend,
+            localizationService: LocalizationService()
+        )
+    }
+
+    /// Builds complete environment values for this runtime.
+    func environmentValues(
+        extending base: EnvironmentValues = EnvironmentValues()
+    ) -> EnvironmentValues {
+        var environment = base
+        environment.stateStorage = stateStorage
+        environment.lifecycle = lifecycle
+        environment.keyEventDispatcher = keyEventDispatcher
+        environment.renderCache = renderCache
+        environment.renderInvalidationSink = appState
+        environment.preferenceStorage = preferences
+        environment.localizationService = localizationService
+        environment.notificationService = notificationService
+        environment.storageBackend = storageBackend
+        environment.runtimeClock = clock
+        environment.focusManager = focusManager
+        environment.paletteManager = paletteManager
+        environment.appearanceManager = appearanceManager
+        environment.statusBar = statusBar
+        environment.appHeader = appHeader
+
+        if let palette = paletteManager.currentPalette {
+            environment.palette = palette
+        }
+        if let appearance = appearanceManager.currentAppearance {
+            environment.appearance = appearance
+        }
+        return environment
+    }
+
     /// Applies cache invalidations queued by state producers.
     ///
     /// This method runs on the render owner before a frame, keeping the
@@ -296,5 +393,8 @@ extension TUIContext {
         preferences.reset()
         stateStorage.reset()
         renderCache.reset()
+        notificationService.clear()
+        focusManager.clear()
+        storageBackend.synchronize()
     }
 }

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -350,6 +350,28 @@ extension TUIContext {
         )
     }
 
+    /// Starts a complete view render pass for this runtime.
+    func beginRenderPass() {
+        keyEventDispatcher.clearHandlers()
+        preferences.beginRenderPass()
+        focusManager.beginRenderPass()
+        statusBar.clearSectionItems()
+        appHeader.beginRenderPass()
+        statusBar.focusManager = focusManager
+        lifecycle.beginRenderPass()
+        stateStorage.beginRenderPass()
+        renderCache.beginRenderPass()
+        applyPendingRenderInvalidations()
+    }
+
+    /// Finishes lifecycle, state, and cache tracking for a render pass.
+    func endRenderPass() {
+        lifecycle.endRenderPass()
+        stateStorage.endRenderPass()
+        renderCache.removeInactive()
+        renderCache.logFrameStats()
+    }
+
     /// Builds complete environment values for this runtime.
     func environmentValues(
         extending base: EnvironmentValues = EnvironmentValues()

--- a/Sources/TUIkit/Environment/TUIContext.swift
+++ b/Sources/TUIkit/Environment/TUIContext.swift
@@ -260,12 +260,10 @@ final class TUIContext {
     /// URL image cache owned by this runtime.
     let imageCache: URLImageCache
 
-    /// Creates a new TUI context with fresh instances of all services.
-    ///
-    /// Each context owns an independent render cache.
     /// Creates a new isolated TUI context with injectable services.
     ///
-    /// Useful for testing where you want to inject mock services.
+    /// Every omitted service is created fresh, so contexts do not share state,
+    /// caches, or service instances. Tests can inject deterministic substitutes.
     ///
     /// - Parameters:
     ///   - appState: The render state and invalidation sink to use.

--- a/Sources/TUIkit/Extensions/View+Presentation.swift
+++ b/Sources/TUIkit/Extensions/View+Presentation.swift
@@ -184,8 +184,9 @@ extension View {
     /// ContentView()
     ///     .notificationHost()
     ///
-    /// // Anywhere in the hierarchy:
-    /// NotificationService.current.post("Saved!")
+    /// // In a descendant view:
+    /// @Environment(\.notificationService) var notifications
+    /// notifications.post("Saved!")
     /// ```
     ///
     /// The base content remains fully interactive — notifications do not dim

--- a/Sources/TUIkit/Focus/Focus.swift
+++ b/Sources/TUIkit/Focus/Focus.swift
@@ -533,7 +533,7 @@ private extension FocusManager {
 
 /// Environment key for the focus manager.
 private struct FocusManagerKey: EnvironmentKey {
-    static let defaultValue = FocusManager()
+    static var defaultValue: FocusManager { FocusManager() }
 }
 
 extension EnvironmentValues {

--- a/Sources/TUIkit/Localization/LocalizationExtensions.swift
+++ b/Sources/TUIkit/Localization/LocalizationExtensions.swift
@@ -20,32 +20,9 @@ extension Text {
     ///
     /// - Parameter key: The dot-notation key for the localized string.
     public init(localized key: String) {
-        let localizedValue = LocalizationService.shared.string(for: key)
+        let localizationService = StateRegistration.activeEnvironment?.localizationService
+            ?? LocalizationService.transient()
+        let localizedValue = localizationService.string(for: key)
         self.init(localizedValue)
-    }
-}
-
-// MARK: - AppState Language Convenience
-
-extension AppState {
-    /// Gets the currently active language.
-    public var currentLanguage: LocalizationService.Language {
-        LocalizationService.shared.currentLanguage
-    }
-
-    /// Changes the active language and triggers a re-render.
-    ///
-    /// The language preference is persisted to disk and will survive app restarts.
-    /// The UI automatically re-renders with the new language strings.
-    ///
-    /// # Example
-    ///
-    /// ```swift
-    /// AppState.shared.setLanguage(.german)
-    /// ```
-    ///
-    /// - Parameter language: The language to activate.
-    public func setLanguage(_ language: LocalizationService.Language) {
-        LocalizationService.shared.setLanguage(language)
     }
 }

--- a/Sources/TUIkit/Localization/LocalizationKeys.swift
+++ b/Sources/TUIkit/Localization/LocalizationKeys.swift
@@ -129,8 +129,8 @@ extension LocalizedString {
     /// # Example
     ///
     /// ```swift
-    /// LocalizedString(.button(.ok))
-    /// LocalizedString(.error(.notFound))
+    /// LocalizedString(LocalizationKey.Button.ok)
+    /// LocalizedString(LocalizationKey.Error.notFound)
     /// ```
     public init(_ key: LocalizationKey.Button) {
         self.init(key.rawValue)
@@ -173,8 +173,8 @@ extension Text {
     /// # Example
     ///
     /// ```swift
-    /// Text(localized: .button(.ok))
-    /// Text(localized: .error(.notFound))
+    /// Text(localized: LocalizationKey.Button.ok)
+    /// Text(localized: LocalizationKey.Error.notFound)
     /// ```
     public init(localized key: LocalizationKey.Button) {
         self.init(localized: key.rawValue)
@@ -218,8 +218,8 @@ extension LocalizationService {
     ///
     /// ```swift
     /// @Environment(\.localizationService) var localization
-    /// let okText = localization.string(for: .button(.ok))
-    /// let errorText = localization.string(for: .error(.notFound))
+    /// let okText = localization.string(for: LocalizationKey.Button.ok)
+    /// let errorText = localization.string(for: LocalizationKey.Error.notFound)
     /// ```
     public func string(for key: LocalizationKey.Button) -> String {
         string(for: key.rawValue)

--- a/Sources/TUIkit/Localization/LocalizationKeys.swift
+++ b/Sources/TUIkit/Localization/LocalizationKeys.swift
@@ -217,8 +217,9 @@ extension LocalizationService {
     /// # Example
     ///
     /// ```swift
-    /// let okText = LocalizationService.shared.string(for: .button(.ok))
-    /// let errorText = LocalizationService.shared.string(for: .error(.notFound))
+    /// @Environment(\.localizationService) var localization
+    /// let okText = localization.string(for: .button(.ok))
+    /// let errorText = localization.string(for: .error(.notFound))
     /// ```
     public func string(for key: LocalizationKey.Button) -> String {
         string(for: key.rawValue)

--- a/Sources/TUIkit/Localization/LocalizationService.swift
+++ b/Sources/TUIkit/Localization/LocalizationService.swift
@@ -33,16 +33,8 @@ public final class LocalizationService: @unchecked Sendable {
         }
     }
 
-    /// The shared localization service instance.
-    public static let shared = LocalizationService()
-
     /// Currently active language
-    public private(set) var currentLanguage: Language {
-        didSet {
-            saveLanguagePreference(currentLanguage)
-            AppState.shared.setNeedsRender()
-        }
-    }
+    public private(set) var currentLanguage: Language
 
     /// Cached translations: [languageCode: [dotPath: localizedString]]
     private var translationCache: [String: [String: String]] = [:]
@@ -53,12 +45,20 @@ public final class LocalizationService: @unchecked Sendable {
     /// Optional config directory override for testing.
     private let configDirectoryOverride: String?
 
+    /// Whether language changes are persisted to a configuration file.
+    private let persistsLanguagePreference: Bool
+
+    /// Runtime receiving invalidation requests after a language change.
+    private var invalidationSink: (any RenderInvalidationSink)?
+
     /// Creates and initializes the localization service.
     ///
     /// Loads the stored language preference, falling back to system locale
     /// or English if unavailable.
     public init() {
         self.configDirectoryOverride = nil
+        self.persistsLanguagePreference = true
+        self.invalidationSink = nil
 
         // Compute initial language before assignment to avoid didSet side effects.
         let initial: Language
@@ -82,6 +82,8 @@ public final class LocalizationService: @unchecked Sendable {
     /// Used for testing to isolate file system access.
     init(configDirectoryPath: String) {
         self.configDirectoryOverride = configDirectoryPath
+        self.persistsLanguagePreference = true
+        self.invalidationSink = nil
 
         let initial: Language
         if let stored = Self.loadLanguagePreference(from: configDirectoryPath) {
@@ -96,13 +98,45 @@ public final class LocalizationService: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Creates an in-memory localization service for isolated runtimes.
+    ///
+    /// The service starts in English and never reads or writes user config.
+    static func transient() -> LocalizationService {
+        LocalizationService(initialLanguage: .english)
+    }
+
+    /// Creates a non-persisting localization service.
+    private init(initialLanguage: Language) {
+        self.configDirectoryOverride = nil
+        self.persistsLanguagePreference = false
+        self.invalidationSink = nil
+        self.currentLanguage = initialLanguage
+
+        lock.lock()
+        _ = _translations(for: currentLanguage)
+        lock.unlock()
+    }
+
     /// Changes the active language and persists the preference.
     ///
     /// - Parameter language: The new language to activate.
     public func setLanguage(_ language: Language) {
         lock.lock()
-        defer { lock.unlock() }
         currentLanguage = language
+        let invalidationSink = invalidationSink
+        lock.unlock()
+
+        if persistsLanguagePreference {
+            saveLanguagePreference(language)
+        }
+        invalidationSink?.invalidate(.all)
+    }
+
+    /// Associates this service with the runtime that owns it.
+    func setInvalidationSink(_ invalidationSink: (any RenderInvalidationSink)?) {
+        lock.lock()
+        self.invalidationSink = invalidationSink
+        lock.unlock()
     }
 
     /// Resolves a localized string using a dot-notation key.

--- a/Sources/TUIkit/Localization/LocalizedString.swift
+++ b/Sources/TUIkit/Localization/LocalizedString.swift
@@ -22,6 +22,9 @@
 ///
 /// Use this for all UI strings that need localization.
 public struct LocalizedString: View {
+    /// Localization service inherited from the owning runtime.
+    @Environment(\.localizationService) private var localizationService
+
     /// The dot-notation key for the string to display.
     private let key: String
 
@@ -33,6 +36,6 @@ public struct LocalizedString: View {
     }
 
     public var body: some View {
-        Text(LocalizationService.shared.string(for: key))
+        Text(localizationService.string(for: key))
     }
 }

--- a/Sources/TUIkit/Notification/NotificationHostModifier.swift
+++ b/Sources/TUIkit/Notification/NotificationHostModifier.swift
@@ -54,10 +54,12 @@ extension NotificationHostModifier: Renderable {
         // Start the animation timer if not already running.
         startAnimationTask(
             entries: activeEntries,
-            lifecycle: context.environment.lifecycle!
+            lifecycle: context.environment.lifecycle!,
+            clock: context.environment.runtimeClock,
+            invalidationSink: context.environment.renderInvalidationSink
         )
 
-        let now = Date().timeIntervalSinceReferenceDate
+        let now = context.environment.runtimeClock.now()
         let palette = context.environment.palette
         let horizontalPadding = 1
         let innerWidth = max(1, width - BorderRenderer.borderWidthOverhead)
@@ -149,7 +151,9 @@ private extension NotificationHostModifier {
     /// The task stops automatically when no notifications are active.
     func startAnimationTask(
         entries: [NotificationEntry],
-        lifecycle: LifecycleManager
+        lifecycle: LifecycleManager,
+        clock: RuntimeClock,
+        invalidationSink: (any RenderInvalidationSink)?
     ) {
         let token = "notification-host-animation"
 
@@ -161,22 +165,22 @@ private extension NotificationHostModifier {
         let latestExpiry = entries.map { $0.postedAt + $0.duration + totalOverhead }
             .max() ?? 0
 
-        lifecycle.startTask(token: token, priority: .medium) { [lifecycle] in
+        lifecycle.startTask(token: token, priority: .medium) { [lifecycle, invalidationSink] in
             let triggerNanos: UInt64 = 23_800_000  // ~24ms (~42 FPS)
 
             while !Task.isCancelled {
-                let now = Date().timeIntervalSinceReferenceDate
+                let now = clock.now()
                 if now > latestExpiry {
                     break
                 }
                 try? await Task.sleep(nanoseconds: triggerNanos)
                 guard !Task.isCancelled else { break }
-                AppState.shared.setNeedsRender()
+                invalidationSink?.invalidate(.renderOnly)
             }
 
             // Final render to clear expired notifications.
             lifecycle.resetAppearance(token: token)
-            AppState.shared.setNeedsRender()
+            invalidationSink?.invalidate(.renderOnly)
         }
     }
 }

--- a/Sources/TUIkit/Notification/NotificationService.swift
+++ b/Sources/TUIkit/Notification/NotificationService.swift
@@ -31,11 +31,11 @@ struct NotificationEntry: Identifiable, Sendable {
     /// - Parameters:
     ///   - message: The notification message text.
     ///   - duration: Display duration in seconds.
-    init(message: String, duration: TimeInterval) {
+    init(message: String, duration: TimeInterval, postedAt: TimeInterval) {
         self.id = UUID()
         self.message = message
         self.duration = duration
-        self.postedAt = Date().timeIntervalSinceReferenceDate
+        self.postedAt = postedAt
     }
 }
 
@@ -50,11 +50,12 @@ struct NotificationEntry: Identifiable, Sendable {
 ///
 /// ## Usage
 ///
-/// Post notifications from anywhere using the shared instance:
+/// Read the service from the environment before posting:
 ///
 /// ```swift
-/// NotificationService.current.post("Saved!")
-/// NotificationService.current.post("Connection lost", duration: 5.0)
+/// @Environment(\.notificationService) private var notifications
+/// notifications.post("Saved!")
+/// notifications.post("Connection lost", duration: 5.0)
 /// ```
 ///
 /// Attach the host once at the root of your view tree:
@@ -74,30 +75,32 @@ struct NotificationEntry: Identifiable, Sendable {
 /// The service automatically removes expired entries and triggers re-renders
 /// for animation frames.
 public final class NotificationService: @unchecked Sendable {
-    /// The shared instance used by the running application.
-    ///
-    /// This is a static accessor rather than environment-only because TUIKit
-    /// does not have an `@Environment` property wrapper. Button callbacks,
-    /// `onSelect` handlers, and other user-facing closures run outside the
-    /// render context and therefore cannot read `EnvironmentValues`. A static
-    /// reference is the only way to reach the service from those call sites.
-    ///
-    /// The same pattern is used by `AppState.shared` for the same reason.
-    /// For tests, create a fresh instance instead of using `current`.
-    ///
-    /// ```swift
-    /// NotificationService.current.post("Done!")
-    /// ```
-    nonisolated(unsafe) public static var current = NotificationService()
-
     /// Lock for thread-safe access to the entries array.
     private let lock = NSLock()
 
     /// The active notification entries, ordered by posting time.
     private var entries: [NotificationEntry] = []
 
+    /// Clock used for posting and pruning entries.
+    private var clock: RuntimeClock
+
+    /// Runtime receiving invalidations after queue changes.
+    private var invalidationSink: (any RenderInvalidationSink)?
+
     /// Creates an empty notification service.
-    public init() {}
+    public init() {
+        self.clock = .system
+        self.invalidationSink = nil
+    }
+
+    /// Creates a notification service with runtime dependencies.
+    init(
+        clock: RuntimeClock,
+        invalidationSink: (any RenderInvalidationSink)?
+    ) {
+        self.clock = clock
+        self.invalidationSink = invalidationSink
+    }
 }
 
 // MARK: - Public API
@@ -111,11 +114,16 @@ extension NotificationService {
     ///   - message: The notification message text.
     ///   - duration: How long the notification stays visible in seconds (default: 3.0).
     public func post(_ message: String, duration: TimeInterval = 3.0) {
-        let entry = NotificationEntry(message: message, duration: duration)
         lock.lock()
+        let entry = NotificationEntry(
+            message: message,
+            duration: duration,
+            postedAt: clock.now()
+        )
         entries.append(entry)
+        let invalidationSink = invalidationSink
         lock.unlock()
-        AppState.shared.setNeedsRender()
+        invalidationSink?.invalidate(.renderOnly)
     }
 
     /// Returns a snapshot of all currently active notifications.
@@ -123,10 +131,10 @@ extension NotificationService {
     /// Entries whose total animation time (fade-in + visible + fade-out) has
     /// elapsed are pruned before the snapshot is returned.
     func activeEntries() -> [NotificationEntry] {
-        let now = Date().timeIntervalSinceReferenceDate
         let totalAnimationOverhead = NotificationTiming.fadeInDuration + NotificationTiming.fadeOutDuration
 
         lock.lock()
+        let now = clock.now()
         entries.removeAll { entry in
             let totalDuration = totalAnimationOverhead + entry.duration
             return (now - entry.postedAt) > totalDuration
@@ -142,23 +150,34 @@ extension NotificationService {
         entries.removeAll()
         lock.unlock()
     }
+
+    /// Associates this service with runtime dependencies.
+    func setRuntimeDependencies(
+        clock: RuntimeClock,
+        invalidationSink: (any RenderInvalidationSink)?
+    ) {
+        lock.lock()
+        self.clock = clock
+        self.invalidationSink = invalidationSink
+        lock.unlock()
+    }
 }
 
 // MARK: - Environment Key
 
 /// Environment key for the notification service.
 private struct NotificationServiceKey: EnvironmentKey {
-    static let defaultValue = NotificationService()
+    static var defaultValue: NotificationService { NotificationService() }
 }
 
 extension EnvironmentValues {
     /// The notification service for posting and managing notifications.
     ///
     /// Used internally by the `NotificationHostModifier` to read active entries.
-    /// Post notifications via the static accessor:
+    /// Read this value with `@Environment` and retain it in callbacks:
     ///
     /// ```swift
-    /// NotificationService.current.post("Saved!")
+    /// @Environment(\.notificationService) private var notifications
     /// ```
     public var notificationService: NotificationService {
         get { self[NotificationServiceKey.self] }

--- a/Sources/TUIkit/Rendering/FrameDiffWriter.swift
+++ b/Sources/TUIkit/Rendering/FrameDiffWriter.swift
@@ -94,19 +94,19 @@ extension FrameDiffWriter {
     }
 
     /// Compares new content lines with the previous frame and writes only changed lines.
-    func writeContentDiff(newLines: [String], terminal: Terminal, startRow: Int) {
+    func writeContentDiff(newLines: [String], terminal: any TerminalProtocol, startRow: Int) {
         writeDiff(newLines: newLines, previousLines: previousContentLines, terminal: terminal, startRow: startRow)
         previousContentLines = newLines
     }
 
     /// Compares new status bar lines with the previous frame and writes only changed lines.
-    func writeStatusBarDiff(newLines: [String], terminal: Terminal, startRow: Int) {
+    func writeStatusBarDiff(newLines: [String], terminal: any TerminalProtocol, startRow: Int) {
         writeDiff(newLines: newLines, previousLines: previousStatusBarLines, terminal: terminal, startRow: startRow)
         previousStatusBarLines = newLines
     }
 
     /// Compares new app header lines with the previous frame and writes only changed lines.
-    func writeAppHeaderDiff(newLines: [String], terminal: Terminal, startRow: Int) {
+    func writeAppHeaderDiff(newLines: [String], terminal: any TerminalProtocol, startRow: Int) {
         writeDiff(newLines: newLines, previousLines: previousAppHeaderLines, terminal: terminal, startRow: startRow)
         previousAppHeaderLines = newLines
     }
@@ -136,7 +136,12 @@ extension FrameDiffWriter {
 
 private extension FrameDiffWriter {
     /// Writes only the lines that differ between two frames.
-    func writeDiff(newLines: [String], previousLines: [String], terminal: Terminal, startRow: Int) {
+    func writeDiff(
+        newLines: [String],
+        previousLines: [String],
+        terminal: any TerminalProtocol,
+        startRow: Int
+    ) {
         let changedRows = Self.computeChangedRows(newLines: newLines, previousLines: previousLines)
 
         for row in changedRows {

--- a/Sources/TUIkit/Rendering/ViewRenderer.swift
+++ b/Sources/TUIkit/Rendering/ViewRenderer.swift
@@ -95,6 +95,14 @@ extension ViewRenderer {
         flush(buffer, atRow: row, column: column)
         terminal.endFrame()
     }
+
+    /// Releases tasks and mutable services owned by this standalone runtime.
+    ///
+    /// Reusable renderers stay alive across calls until their owner explicitly
+    /// shuts them down. The public one-shot API calls this after its only frame.
+    func shutdown() {
+        tuiContext.reset()
+    }
 }
 
 // MARK: - Private Helpers

--- a/Sources/TUIkit/Rendering/ViewRenderer.swift
+++ b/Sources/TUIkit/Rendering/ViewRenderer.swift
@@ -7,8 +7,7 @@
 /// Convenience class for standalone one-off view rendering.
 ///
 /// `ViewRenderer` wraps the free function ``renderToBuffer(_:context:)``
-/// with terminal cursor positioning. It is a thin wrapper — the actual
-/// rendering dispatch happens in `renderToBuffer`, not here.
+/// with a complete one-pass runtime and terminal cursor positioning.
 ///
 /// This class is **not** part of the main render pipeline. The main
 /// pipeline is:
@@ -18,19 +17,28 @@
 /// ```
 ///
 /// `ViewRenderer` is used by the ``renderOnce(_:)`` convenience API
-/// for simple CLI tools that don't need a full ``App``. It bypasses
-/// `RenderLoop`, `FrameDiffWriter`, environment, lifecycle tracking,
-/// and diff-based rendering.
+/// for simple CLI tools that don't need a full ``App``. It shares the
+/// runtime environment and render-pass lifecycle used by `RenderLoop`,
+/// while intentionally omitting event-loop and diff-rendering behavior.
 @MainActor
 final class ViewRenderer {
     /// The terminal to render to.
-    private let terminal: Terminal
+    private let terminal: any TerminalProtocol
+
+    /// Complete runtime used for the standalone render pass.
+    private let tuiContext: TUIContext
 
     /// Creates a new ViewRenderer.
     ///
-    /// - Parameter terminal: The target terminal (default: new Terminal instance).
-    init(terminal: Terminal? = nil) {
+    /// - Parameters:
+    ///   - terminal: The target terminal. Defaults to a production terminal.
+    ///   - tuiContext: The runtime to use. Defaults to a production runtime.
+    init(
+        terminal: (any TerminalProtocol)? = nil,
+        tuiContext: TUIContext? = nil
+    ) {
         self.terminal = terminal ?? Terminal()
+        self.tuiContext = tuiContext ?? TUIContext.production()
     }
 }
 
@@ -47,13 +55,45 @@ extension ViewRenderer {
     ///   - row: The starting row (1-based, default: 1).
     ///   - column: The starting column (1-based, default: 1).
     func render<V: View>(_ view: V, atRow row: Int = 1, column: Int = 1) {
+        render(atRow: row, column: column) {
+            view
+        }
+    }
+
+    /// Builds and renders a view inside a complete runtime render pass.
+    ///
+    /// Constructing the root while hydration is active lets root-level
+    /// property wrappers bind to the same runtime as nested views.
+    func render<V: View>(
+        atRow row: Int = 1,
+        column: Int = 1,
+        @ViewBuilder content: () -> V
+    ) {
+        tuiContext.beginRenderPass()
+        defer {
+            tuiContext.focusManager.endRenderPass()
+            tuiContext.endRenderPass()
+        }
+
         let size = terminal.getSize()
-        let context = RenderContext(
+        let rootIdentity = ViewIdentity(rootType: V.self)
+        var context = RenderContext(
             availableWidth: size.width,
-            availableHeight: size.height
+            availableHeight: size.height,
+            tuiContext: tuiContext,
+            identity: rootIdentity
         )
+        context.hasExplicitWidth = true
+        context.hasExplicitHeight = true
+        let view = StateRegistration.withHydration(context: context) {
+            content()
+        }
+        tuiContext.stateStorage.markActive(rootIdentity)
         let buffer = renderToBuffer(view, context: context)
+
+        terminal.beginFrame()
         flush(buffer, atRow: row, column: column)
+        terminal.endFrame()
     }
 }
 

--- a/Sources/TUIkit/State/AppStorage.swift
+++ b/Sources/TUIkit/State/AppStorage.swift
@@ -195,11 +195,12 @@ private extension JSONFileStorage {
 
 /// Provides the default storage backend for ``AppStorage``.
 ///
-/// Override the backend before creating any `@AppStorage` properties
-/// if you want to use a custom storage backend.
+/// This global compatibility hook is deprecated. `@AppStorage` properties
+/// rendered inside an app bind to that app's runtime backend. Pass an explicit
+/// backend to the property wrapper when code outside a runtime needs one.
 ///
 /// ```swift
-/// StorageDefaults.backend = MyCustomBackend()
+/// @AppStorage("token", storage: MyCustomBackend()) var token = ""
 /// ```
 public enum StorageDefaults {
     /// Backing storage retained until issue #15 removes the global fallback.
@@ -209,7 +210,7 @@ public enum StorageDefaults {
     ///
     /// Defaults to a ``JSONFileStorage`` instance that persists to
     /// `$XDG_CONFIG_HOME/[appName]/settings.json`.
-    @available(*, deprecated, message: "Inject storage through the application runtime instead")
+    @available(*, deprecated, message: "Pass a StorageBackend to the AppStorage initializer instead")
     public static var backend: StorageBackend {
         get { configuredBackend }
         set { configuredBackend = newValue }

--- a/Sources/TUIkit/State/AppStorage.swift
+++ b/Sources/TUIkit/State/AppStorage.swift
@@ -297,10 +297,7 @@ public struct AppStorage<Value: Codable>: @unchecked Sendable {
 
     /// A binding to the stored value.
     public var projectedValue: Binding<Value> {
-        Binding(
-            get: { self.wrappedValue },
-            set: { self.wrappedValue = $0 }
-        )
+        box.binding
     }
 }
 
@@ -356,6 +353,15 @@ private final class AppStorageBox<Value: Codable>: @unchecked Sendable {
                 dependencies.invalidationSink?.invalidate(.all)
             }
         }
+    }
+
+    /// Binding captured while the property wrapper is hydrated by its runtime.
+    var binding: Binding<Value> {
+        bindToActiveRuntimeIfNeeded()
+        return Binding(
+            get: { self.value },
+            set: { self.value = $0 }
+        )
     }
 }
 

--- a/Sources/TUIkit/State/AppStorage.swift
+++ b/Sources/TUIkit/State/AppStorage.swift
@@ -202,11 +202,23 @@ private extension JSONFileStorage {
 /// StorageDefaults.backend = MyCustomBackend()
 /// ```
 public enum StorageDefaults {
+    /// Backing storage retained until issue #15 removes the global fallback.
+    nonisolated(unsafe) private static var configuredBackend: StorageBackend = JSONFileStorage()
+
     /// The default storage backend used by ``AppStorage``.
     ///
     /// Defaults to a ``JSONFileStorage`` instance that persists to
     /// `$XDG_CONFIG_HOME/[appName]/settings.json`.
-    nonisolated(unsafe) public static var backend: StorageBackend = JSONFileStorage()
+    @available(*, deprecated, message: "Inject storage through the application runtime instead")
+    public static var backend: StorageBackend {
+        get { configuredBackend }
+        set { configuredBackend = newValue }
+    }
+
+    /// Legacy fallback used only when AppStorage is accessed outside a runtime.
+    static var runtimeBackend: StorageBackend {
+        configuredBackend
+    }
 }
 
 // MARK: - AppStorage Property Wrapper
@@ -242,14 +254,8 @@ public enum StorageDefaults {
 /// - Custom Codable structs and enums
 @propertyWrapper
 public struct AppStorage<Value: Codable>: @unchecked Sendable {
-    /// The key used for storage.
-    private let key: String
-
-    /// The default value if no stored value exists.
-    private let defaultValue: Value
-
-    /// The storage backend to use.
-    private let storage: StorageBackend
+    /// Reference storage that captures the first runtime owning this property.
+    private let box: AppStorageBox<Value>
 
     /// Creates an AppStorage with the default storage backend.
     ///
@@ -257,9 +263,11 @@ public struct AppStorage<Value: Codable>: @unchecked Sendable {
     ///   - wrappedValue: The default value.
     ///   - key: The key to use for storage.
     public init(wrappedValue: Value, _ key: String) {
-        self.key = key
-        self.defaultValue = wrappedValue
-        self.storage = StorageDefaults.backend
+        self.box = AppStorageBox(
+            key: key,
+            defaultValue: wrappedValue,
+            explicitStorage: nil
+        )
     }
 
     /// Creates an AppStorage with a custom storage backend.
@@ -269,19 +277,20 @@ public struct AppStorage<Value: Codable>: @unchecked Sendable {
     ///   - key: The key to use for storage.
     ///   - storage: The storage backend to use.
     public init(wrappedValue: Value, _ key: String, storage: StorageBackend) {
-        self.key = key
-        self.defaultValue = wrappedValue
-        self.storage = storage
+        self.box = AppStorageBox(
+            key: key,
+            defaultValue: wrappedValue,
+            explicitStorage: storage
+        )
     }
 
     /// The current value.
     public var wrappedValue: Value {
         get {
-            storage.value(forKey: key) ?? defaultValue
+            box.value
         }
         nonmutating set {
-            storage.setValue(newValue, forKey: key)
-            AppState.shared.setNeedsRender()
+            box.value = newValue
         }
     }
 
@@ -291,5 +300,93 @@ public struct AppStorage<Value: Codable>: @unchecked Sendable {
             get: { self.wrappedValue },
             set: { self.wrappedValue = $0 }
         )
+    }
+}
+
+// MARK: - App Storage Box
+
+/// Reference storage that binds AppStorage to its first rendering runtime.
+private final class AppStorageBox<Value: Codable>: @unchecked Sendable {
+    /// Persistent key.
+    private let key: String
+
+    /// Value returned when the backend contains no entry.
+    private let defaultValue: Value
+
+    /// Explicit backend supplied by the property-wrapper initializer.
+    private let explicitStorage: StorageBackend?
+
+    /// Backend captured from the owning runtime.
+    private var runtimeStorage: StorageBackend?
+
+    /// Runtime receiving changes made through this property.
+    private var invalidationSink: (any RenderInvalidationSink)?
+
+    /// Structural identity owning this property.
+    private var identity: ViewIdentity?
+
+    /// Lock protecting dependency binding.
+    private let lock = NSLock()
+
+    /// Creates reference storage for one AppStorage property.
+    init(
+        key: String,
+        defaultValue: Value,
+        explicitStorage: StorageBackend?
+    ) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.explicitStorage = explicitStorage
+    }
+
+    /// Current persisted value.
+    var value: Value {
+        get {
+            let storage = resolvedDependencies().storage
+            return storage.value(forKey: key) ?? defaultValue
+        }
+        set {
+            let dependencies = resolvedDependencies()
+            dependencies.storage.setValue(newValue, forKey: key)
+
+            if let identity = dependencies.identity {
+                dependencies.invalidationSink?.invalidate(.subtree(identity))
+            } else {
+                dependencies.invalidationSink?.invalidate(.all)
+            }
+        }
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension AppStorageBox {
+    typealias Dependencies = (
+        storage: StorageBackend,
+        invalidationSink: (any RenderInvalidationSink)?,
+        identity: ViewIdentity?
+    )
+
+    func resolvedDependencies() -> Dependencies {
+        bindToActiveRuntimeIfNeeded()
+
+        lock.lock()
+        let storage = explicitStorage ?? runtimeStorage ?? StorageDefaults.runtimeBackend
+        let invalidationSink = invalidationSink
+        let identity = identity
+        lock.unlock()
+        return (storage, invalidationSink, identity)
+    }
+
+    func bindToActiveRuntimeIfNeeded() {
+        guard let environment = StateRegistration.activeEnvironment else { return }
+
+        lock.lock()
+        if runtimeStorage == nil {
+            runtimeStorage = environment.storageBackend
+            invalidationSink = environment.renderInvalidationSink
+            identity = StateRegistration.activeContext?.identity
+        }
+        lock.unlock()
     }
 }

--- a/Sources/TUIkit/StatusBar/StatusBarState.swift
+++ b/Sources/TUIkit/StatusBar/StatusBarState.swift
@@ -323,7 +323,7 @@ private extension StatusBarState {
 
 /// Environment key for accessing the status bar state.
 private struct StatusBarKey: EnvironmentKey {
-    static let defaultValue = StatusBarState()
+    static var defaultValue: StatusBarState { StatusBarState() }
 }
 
 extension EnvironmentValues {

--- a/Sources/TUIkit/TUIkit.docc/Articles/AppLifecycle.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/AppLifecycle.md
@@ -33,13 +33,29 @@ The `@main` attribute tells Swift to call the static `main()` method provided by
 
 ## Subsystem Initialization
 
-`AppRunner.init()` creates and wires the core subsystems: Terminal, AppState, StatusBarState, AppHeaderState, FocusManager, TUIContext (containing LifecycleManager, KeyEventDispatcher, PreferenceStorage, StateStorage, and RenderCache), and two ThemeManagers (palette and appearance). `run()` then creates the remaining runtime components: InputHandler, RenderLoop, PulseTimer (100 ms), and CursorTimer (50 ms).
+`AppRunner.init()` creates a terminal session, a signal manager, and one
+`TUIContext`. The context is the sole owner of the application's mutable runtime
+services. `run()` then creates the session components that consume those services:
+`InputHandler`, `RenderLoop`, `PulseTimer`, and `CursorTimer`.
 
-@Image(source: "lifecycle-subsystem-init.png", alt: "Diagram showing subsystem initialization: @main calls App.main(), which creates the app instance via Self(), then AppRunner.init() creates Terminal, AppState, StatusBarState, AppHeaderState, FocusManager, TUIContext with 5 children (LifecycleManager, KeyEventDispatcher, PreferenceStorage, StateStorage, RenderCache), and two ThemeManagers.")
+```
+AppRunner
+├── Terminal session
+├── SignalManager
+└── TUIContext
+    ├── AppState, StateStorage, RenderCache
+    ├── LifecycleManager, KeyEventDispatcher, PreferenceStorage
+    ├── LocalizationService, NotificationService, StorageBackend, RuntimeClock
+    ├── FocusManager, palette and appearance managers
+    ├── StatusBarState, AppHeaderState
+    └── ImageLoader, URLImageCache
+```
 
 @Image(source: "lifecycle-run-creates.png", alt: "Diagram showing run() creating InputHandler, RenderLoop, PulseTimer (100ms), and CursorTimer (50ms).")
 
-The `AppRunner` is the sole owner of all subsystems. Dependencies flow through constructor injection and ``RenderContext``.
+`AppRunner` owns the session. `TUIContext` owns the view-facing runtime services.
+Dependencies flow through constructor injection and ``EnvironmentValues`` inside
+``RenderContext``. The render context itself never owns or accesses a terminal.
 
 ## Terminal Setup
 
@@ -80,7 +96,7 @@ Several sources cause a new frame to be rendered, all converging on two boolean 
 | Trigger | Path | Main loop check |
 |---------|------|-----------------|
 | SIGWINCH | Sets `signalNeedsRerender` + `signalTerminalResized` | `consumeRerenderFlag()` |
-| @State mutation | `AppState` observer calls `signals.requestRerender()` | `consumeRerenderFlag()` |
+| @State mutation | Owning runtime invalidates its subtree and notifies `AppState` | `consumeRerenderFlag()` |
 | PulseTimer / CursorTimer | Calls `appState.setNeedsRender()` | `appState.needsRender` |
 | Focus change | Calls `appState.setNeedsRender()` | `appState.needsRender` |
 
@@ -161,7 +177,7 @@ When the main loop exits: via Ctrl+C, the quit key, or programmatic shutdown: `c
 | 3 | Exit alternate screen | Restore the user's previous terminal content |
 | 4 | Clear state observers | Remove `AppState` observer callbacks |
 | 5 | Clear focus | Remove all focus registrations |
-| 6 | Reset TUIContext | Clear lifecycle, key handlers, and preferences |
+| 6 | Reset TUIContext | Clear runtime state, lifecycle, handlers, caches, notifications, and focus; synchronize app storage |
 
 The `Terminal` class also has a `deinit` safety net that disables raw mode if it was not explicitly restored.
 
@@ -169,12 +185,15 @@ The `Terminal` class also has a `deinit` safety net that disables raw mode if it
 
 ### Ownership
 
-AppRunner creates and owns every subsystem. TUIContext acts as a secondary container for lifecycle, key dispatch, and preference storage.
-
-@Image(source: "dep-graph-ownership.png", alt: "Ownership diagram showing AppRunner owning all subsystems: SignalManager, Terminal, AppState, StatusBarState, AppHeaderState, FocusManager, both ThemeManagers, TUIContext, InputHandler, RenderLoop, PulseTimer, and CursorTimer. TUIContext contains LifecycleManager, KeyEventDispatcher, PreferenceStorage, StateStorage, and RenderCache. SignalManager sends SIGINT and SIGWINCH flags back to AppRunner.")
+`AppRunner` owns the terminal and signals. Its single `TUIContext` owns every
+mutable runtime service used by the view tree. A second runner receives a second
+context, so neither application can invalidate or reuse the other's state,
+caches, focus, localization, notifications, storage, or image requests.
 
 ### Runtime References
 
-During each frame, RenderLoop and InputHandler reference shared subsystems to build the environment and dispatch key events.
-
-@Image(source: "dep-graph-references.png", alt: "Runtime reference diagram showing RenderLoop writing output to Terminal, injecting environment values from StatusBarState, AppHeaderState, FocusManager, and both ThemeManagers, calling begin/end pass on LifecycleManager, StateStorage, and RenderCache, begin pass on PreferenceStorage, and clearing handlers on KeyEventDispatcher. InputHandler dispatches through Layer 0+3 FocusManager, Layer 1 StatusBarState, Layer 2 KeyEventDispatcher, and Layer 4 both ThemeManagers.")
+During each frame, `RenderLoop` obtains a complete environment from `TUIContext`,
+renders into a ``FrameBuffer``, then writes that buffer through the injected
+terminal session. `InputHandler` receives the same context-owned focus, status
+bar, key dispatch, palette, and appearance services. Timers invalidate only that
+context's `AppState`.

--- a/Sources/TUIkit/TUIkit.docc/Articles/Architecture.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/Architecture.md
@@ -57,7 +57,7 @@ Text("Hello")
 - **``State``**: Mutable per-view state that triggers re-renders
 - **``Binding``**: Two-way connection to a value owned elsewhere
 - **``EnvironmentValues``**: Values propagated down the view tree
-- **``AppStorage``**: Persistent key-value storage via `UserDefaults`
+- **``AppStorage``**: Persistent key-value storage through the app runtime
 
 ### 6. Rendering Layer
 
@@ -79,7 +79,12 @@ and URL loading feed data into that deterministic decoder rather than participat
 
 ## Event Loop
 
-`AppRunner` initializes all subsystems (Terminal, AppState, StatusBarState, AppHeaderState, FocusManager, ThemeManager x2, TUIContext), creates InputHandler and RenderLoop, installs POSIX signal handlers, sets up the terminal (alternate screen, raw mode), starts PulseTimer (100 ms) and CursorTimer (50 ms), registers state and focus observers, and performs an initial render before entering the main loop.
+`AppRunner` owns the terminal session and signal manager plus one `TUIContext`.
+That context owns the application's render state, storage, caches, localization,
+notifications, focus, themes, image loading, and other view-facing services.
+`AppRunner` creates `InputHandler` and `RenderLoop`, installs POSIX signal handlers,
+sets up the terminal, starts `PulseTimer` and `CursorTimer`, registers state and
+focus observers, and performs an initial render before entering the main loop.
 
 Each loop iteration checks `shouldShutdown` (set by SIGINT), consumes the resize flag to invalidate the diff cache if SIGWINCH fired, then renders when `consumeRerenderFlag()` or `appState.needsRender` is true. After rendering, it reads up to 128 non-blocking key events per frame and dispatches each through five handler layers. A `usleep(28_000)` throttles the loop to approximately 35 FPS. Asynchronous render triggers (timers, @State changes, SIGWINCH, focus changes) feed back into the render decision via `appState.needsRender` or `signals.requestRerender()`.
 

--- a/Sources/TUIkit/TUIkit.docc/Articles/GettingStarted.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/GettingStarted.md
@@ -83,7 +83,7 @@ struct CounterView: View {
 
 ## One-Shot Rendering
 
-For simple scripts that don't need a full app lifecycle, use ``renderOnce(content:)``:
+For scripts that don't need an event loop, use ``renderOnce(content:)``:
 
 ```swift
 import TUIkit
@@ -99,6 +99,10 @@ renderOnce {
     }
 }
 ```
+
+One-shot rendering uses the same complete runtime contract as an app render.
+Composite views and property wrappers such as ``State``, ``AppStorage``, and
+``Environment`` are supported, but no input loop is started after the frame is written.
 
 ## Next Steps
 

--- a/Sources/TUIkit/TUIkit.docc/Articles/Localization.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/Localization.md
@@ -25,16 +25,16 @@ Use `LocalizedString` to show localized text:
 import TUIkit
 
 VStack {
-    LocalizedString(.button(.ok))
-    LocalizedString(.error(.notFound))
-    LocalizedString(.dialog(.confirm))
+    LocalizedString(LocalizationKey.Button.ok)
+    LocalizedString(LocalizationKey.Error.notFound)
+    LocalizedString(LocalizationKey.Dialog.confirm)
 }
 ```
 
 Or use the `Text(localized:)` convenience initializer:
 
 ```swift
-Text(localized: .button(.save))
+Text(localized: LocalizationKey.Button.save)
 ```
 
 ### Switch Language at Runtime
@@ -147,9 +147,9 @@ Display a localized string as a View component:
 struct MyView: View {
     var body: some View {
         VStack {
-            LocalizedString(.button(.save))
-            LocalizedString(.error(.invalidInput))
-            LocalizedString(.validation(.emailInvalid))
+            LocalizedString(LocalizationKey.Button.save)
+            LocalizedString(LocalizationKey.Error.invalidInput)
+            LocalizedString(LocalizationKey.Validation.emailInvalid)
         }
     }
 }
@@ -163,8 +163,8 @@ Use the `Text(localized:)` initializer:
 struct MyControl: View {
     var body: some View {
         VStack {
-            Text(localized: .menu(.file))
-            Text(localized: .placeholder(.search))
+            Text(localized: LocalizationKey.Menu.file)
+            Text(localized: LocalizationKey.Placeholder.search)
         }
     }
 }
@@ -179,7 +179,7 @@ struct StatusLabel: View {
     @Environment(\.localizationService) private var localization
 
     var body: some View {
-        Text(localization.string(for: .button(.ok)))
+        Text(localization.string(for: LocalizationKey.Button.ok))
     }
 }
 ```
@@ -235,7 +235,7 @@ struct MyView: View {
     @Environment(\.localizationService) var localization
 
     var body: some View {
-        Text(localization.string(for: .button(.ok)))
+        Text(localization.string(for: LocalizationKey.Button.ok))
     }
 }
 ```
@@ -381,7 +381,7 @@ Create `Sources/TUIkit/Localization/translations/pt.json` with **all** keys from
 ```swift
 let service = LocalizationService()
 service.setLanguage(.portuguese)
-let ok = service.string(for: .button(.ok))
+let ok = service.string(for: LocalizationKey.Button.ok)
 ```
 
 ### 4. Run Consistency Tests
@@ -430,8 +430,8 @@ DispatchQueue.global().async {
 Translations are cached per language after first load:
 
 ```swift
-let text1 = service.string(for: .button(.ok))  // Loads and caches
-let text2 = service.string(for: .button(.ok))  // Uses cache
+let text1 = service.string(for: LocalizationKey.Button.ok)  // Loads and caches
+let text2 = service.string(for: LocalizationKey.Button.ok)  // Uses cache
 ```
 
 ## JSON File Format

--- a/Sources/TUIkit/TUIkit.docc/Articles/Localization.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/Localization.md
@@ -40,9 +40,18 @@ Text(localized: .button(.save))
 ### Switch Language at Runtime
 
 ```swift
-AppState.shared.setLanguage(.german)
-// UI automatically re-renders with German strings
+struct LanguagePicker: View {
+    @Environment(\.localizationService) private var localization
+
+    var body: some View {
+        Button("Deutsch") {
+            localization.setLanguage(.german)
+        }
+    }
+}
 ```
+
+The runtime-owned service invalidates only its application and the UI re-renders with German strings.
 
 ### Supported Languages
 
@@ -163,11 +172,16 @@ struct MyControl: View {
 
 ### Direct Service Access
 
-For advanced use cases, access the service directly:
+For advanced use cases, read the runtime-owned service from the environment:
 
 ```swift
-let service = LocalizationService.shared
-let text = service.string(for: .button(.ok))
+struct StatusLabel: View {
+    @Environment(\.localizationService) private var localization
+
+    var body: some View {
+        Text(localization.string(for: .button(.ok)))
+    }
+}
 ```
 
 ## Language Switching
@@ -175,18 +189,23 @@ let text = service.string(for: .button(.ok))
 ### Get Current Language
 
 ```swift
-let current = AppState.shared.currentLanguage
-print(current.displayName)  // "English", "Deutsch", etc.
+struct CurrentLanguageLabel: View {
+    @Environment(\.currentLanguage) private var currentLanguage
+
+    var body: some View {
+        Text(currentLanguage.displayName)
+    }
+}
 ```
 
 ### Change Language
 
 ```swift
-// Via AppState
-AppState.shared.setLanguage(.german)
+@Environment(\.localizationService) private var localization
 
-// Or directly via service
-LocalizationService.shared.setLanguage(.french)
+Button("Français") {
+    localization.setLanguage(.french)
+}
 ```
 
 ### Language Persistence
@@ -220,6 +239,11 @@ struct MyView: View {
     }
 }
 ```
+
+Each application runtime owns its localization service. The former
+`LocalizationService.shared` and `AppState.shared` accessors are no longer
+available. Reading the service from `@Environment` also ensures that a language
+change invalidates the correct application when multiple runtimes share a process.
 
 ## Adding New Keys
 
@@ -395,8 +419,9 @@ This provides type safety, IDE autocomplete, and compile-time verification.
 
 ```swift
 // Safe to call from any thread
+let service = localization
 DispatchQueue.global().async {
-    AppState.shared.setLanguage(.german)
+    service.setLanguage(.german)
 }
 ```
 
@@ -484,7 +509,7 @@ swift test --filter LocalizationKeyConsistencyTests
 
 ### Wrong Language Showing
 
-- Verify language was set: `AppState.shared.currentLanguage`
+- Verify `@Environment(\.currentLanguage)` reports the expected language
 - Confirm language is supported (en, de, fr, it, es)
 - Check translation file exists for that language
 

--- a/Sources/TUIkit/TUIkit.docc/Articles/RenderCycle.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/RenderCycle.md
@@ -13,7 +13,7 @@ Several sources cause `RenderLoop` to produce a new frame. They converge on two 
 | Trigger | Source | Mechanism |
 |---------|--------|-----------|
 | Terminal resize | `SIGWINCH` signal | `SignalManager` sets `signalNeedsRerender` and `signalTerminalResized` |
-| State mutation | `@State` property change | `AppState` observer calls `signals.requestRerender()` |
+| State mutation | `@State` property change | The owning runtime's invalidation sink notifies `AppState` |
 | Animation timers | PulseTimer (100 ms) / CursorTimer (50 ms) | Calls `appState.setNeedsRender()` |
 | Focus change | `FocusManager.onFocusChange` | Resets pulse timer and calls `appState.setNeedsRender()` |
 
@@ -45,28 +45,30 @@ The `LifecycleManager` prepares for a new frame by clearing its `currentRenderTo
 
 ### Step 3: Build Environment
 
-A fresh ``EnvironmentValues`` instance is assembled from the current subsystem state:
+A fresh ``EnvironmentValues`` instance is assembled from the owning runtime:
 
 ```swift
-// Simplified from RenderLoop.buildEnvironment()
+// Simplified from TUIContext.environmentValues()
 var env = EnvironmentValues()
-env.statusBar           = statusBar
-env.appHeader           = appHeader
-env.focusManager        = focusManager
-env.paletteManager      = paletteManager
-env.palette             = paletteManager.currentPalette
-env.appearanceManager   = appearanceManager
-env.appearance          = appearanceManager.currentAppearance
-env.notificationService = NotificationService.current
+env.renderInvalidationSink = tuiContext.appState
 env.stateStorage        = tuiContext.stateStorage
+env.renderCache         = tuiContext.renderCache
+env.storageBackend      = tuiContext.storageBackend
 env.lifecycle           = tuiContext.lifecycle
 env.keyEventDispatcher  = tuiContext.keyEventDispatcher
-env.renderCache         = tuiContext.renderCache
 env.preferenceStorage   = tuiContext.preferences
-env.localizationService = LocalizationService.shared
+env.localizationService = tuiContext.localizationService
+env.notificationService = tuiContext.notificationService
+env.focusManager        = tuiContext.focusManager
+env.paletteManager      = tuiContext.paletteManager
+env.appearanceManager   = tuiContext.appearanceManager
+env.imageLoader         = tuiContext.imageLoader
+env.imageCache          = tuiContext.imageCache
 ```
 
-This environment is immutable for the duration of the frame. Runtime services (state storage, lifecycle, key dispatch, render cache, preferences) are injected here so that views and modifiers can access them through the environment rather than through `TUIContext` directly.
+This environment is immutable for the duration of the frame. Every application
+owns its service instances, and views access them through the environment rather
+than through `TUIContext` or process-wide service globals.
 
 ### Step 4: Create Render Context
 
@@ -77,7 +79,6 @@ A ``RenderContext`` bundles everything a view needs to render:
 | `availableWidth` | Terminal width (mutable: containers reduce this for children) |
 | `availableHeight` | Terminal height minus status bar (mutable) |
 | `environment` | The ``EnvironmentValues`` from step 3 |
-| `tuiContext` | The `TUIContext` (lifecycle, key dispatch, preferences, state storage) |
 | `identity` | The current view's structural identity (`ViewIdentity`) |
 
 `RenderContext` is a pure data container: it does not hold a reference to `Terminal`. All terminal I/O happens after the view tree has been rendered into a ``FrameBuffer``.
@@ -381,14 +382,17 @@ FeatureBox("Pure Swift", "No ncurses").equatable()
 
 ### Cache Invalidation
 
-The `RenderCache` is **fully cleared** in two situations:
+The runtime applies pending cache invalidations before rendering:
 
 | Trigger | Mechanism |
 |---------|-----------|
-| Any `@State` change | `StateBox.value.didSet` calls `renderCache.clearAll()` |
+| `@State` or `@AppStorage` change | Invalidates the owning view subtree |
+| Observed model or language change | Requests a full runtime cache clear |
 | Environment change | `RenderLoop` compares an `EnvironmentSnapshot` (palette ID + appearance ID) each frame and clears on mismatch |
 
-Between these events: for example during Spinner animation frames at 25 FPS: the cache is fully active. Static subtrees are rendered once and reused for every subsequent frame.
+Each runtime owns its own `RenderCache`, so invalidation in one application cannot
+evict another application's cached output. Between invalidations, for example
+during Spinner animation frames, static subtrees are reused across frames.
 
 ### When to Use `.equatable()`
 

--- a/Sources/TUIkit/TUIkit.docc/Articles/StateManagement.md
+++ b/Sources/TUIkit/TUIkit.docc/Articles/StateManagement.md
@@ -85,7 +85,8 @@ ContentView()
 
 ## @AppStorage
 
-``AppStorage`` persists values across app launches using `UserDefaults`:
+``AppStorage`` persists values across app launches using the application's
+runtime-owned storage backend. TUIkit apps use ``JSONFileStorage`` by default:
 
 ```swift
 struct SettingsView: View {
@@ -95,6 +96,13 @@ struct SettingsView: View {
         Text("Hello, \(username)!")
     }
 }
+```
+
+Pass an explicit backend when a property wrapper is created outside the app
+runtime or needs dedicated storage:
+
+```swift
+@AppStorage("username", storage: MyStorageBackend()) var username = "Guest"
 ```
 
 ## How State Survives Re-Rendering
@@ -113,7 +121,7 @@ This path is built automatically during rendering based on:
 
 ### Persistent State Storage
 
-All `@State` values live in a central `StateStorage` (owned by `TUIContext`), keyed by:
+All `@State` values live in the owning runtime's `StateStorage`, keyed by:
 - The view's structural identity
 - The property's declaration index within the view (0, 1, 2, ...)
 
@@ -124,11 +132,11 @@ exists for this position. If it does, the existing value is used instead of the 
 
 When a ``State`` value changes:
 
-1. The `StateBox` triggers `RenderNotifier.current` -> `AppState.setNeedsRender()`
-2. The observer registered by `AppRunner` requests a re-render
+1. The `StateBox` sends a subtree invalidation to its runtime's `RenderInvalidationSink`
+2. That runtime's `AppState` notifies the observer registered by `AppRunner`
 3. The main loop re-evaluates `app.body` fresh: reconstructing all views
-4. Each `@State.init` self-hydrates from `StateStorage`, recovering persisted values
-5. The new ``FrameBuffer`` output is written to the terminal
+4. Each `@State.init` self-hydrates from the same runtime's `StateStorage`
+5. The owning runtime clears the affected cached subtree and writes the new ``FrameBuffer``
 
 ### Garbage Collection
 

--- a/Sources/TUIkit/TUIkit.swift
+++ b/Sources/TUIkit/TUIkit.swift
@@ -45,5 +45,6 @@ public let tuiKitVersion: String = {
 @MainActor
 public func renderOnce<Content: View>(@ViewBuilder content: () -> Content) {
     let renderer = ViewRenderer()
+    defer { renderer.shutdown() }
     renderer.render(content: content)
 }

--- a/Sources/TUIkit/TUIkit.swift
+++ b/Sources/TUIkit/TUIkit.swift
@@ -44,7 +44,6 @@ public let tuiKitVersion: String = {
 /// - Parameter content: A ViewBuilder closure that defines the view to render.
 @MainActor
 public func renderOnce<Content: View>(@ViewBuilder content: () -> Content) {
-    let view = content()
     let renderer = ViewRenderer()
-    renderer.render(view)
+    renderer.render(content: content)
 }

--- a/Sources/TUIkit/Views/Image.swift
+++ b/Sources/TUIkit/Views/Image.swift
@@ -133,6 +133,16 @@ private struct ImageURLTimeoutKey: EnvironmentKey {
     static let defaultValue: TimeInterval = 30
 }
 
+/// Environment key for the runtime-owned image loader.
+private struct ImageLoaderKey: EnvironmentKey {
+    static var defaultValue: any ImageLoader { PlatformImageLoader() }
+}
+
+/// Environment key for the runtime-owned URL image cache.
+private struct ImageCacheKey: EnvironmentKey {
+    static var defaultValue: URLImageCache { URLImageCache() }
+}
+
 // MARK: - EnvironmentValues
 
 extension EnvironmentValues {
@@ -195,6 +205,18 @@ extension EnvironmentValues {
     var imageURLTimeout: TimeInterval {
         get { self[ImageURLTimeoutKey.self] }
         set { self[ImageURLTimeoutKey.self] = newValue }
+    }
+
+    /// Loader used for file and URL image requests in this runtime.
+    var imageLoader: any ImageLoader {
+        get { self[ImageLoaderKey.self] }
+        set { self[ImageLoaderKey.self] = newValue }
+    }
+
+    /// URL image cache owned by this runtime.
+    var imageCache: URLImageCache {
+        get { self[ImageCacheKey.self] }
+        set { self[ImageCacheKey.self] = newValue }
     }
 }
 

--- a/Sources/TUIkit/Views/Spinner.swift
+++ b/Sources/TUIkit/Views/Spinner.swift
@@ -272,10 +272,12 @@ private struct _SpinnerCore: View, Renderable {
     func renderToBuffer(context: RenderContext) -> FrameBuffer {
         let lifecycle = context.environment.lifecycle!
         let stateStorage = context.environment.stateStorage!
+        let clock = context.environment.runtimeClock
+        let invalidationSink = context.environment.renderInvalidationSink
 
         // Retrieve or create persistent start time for this spinner.
         let timeKey = StateStorage.StateKey(identity: context.identity, propertyIndex: 0)
-        let startTimeBox: StateBox<Double> = stateStorage.storage(for: timeKey, default: Date().timeIntervalSinceReferenceDate)
+        let startTimeBox: StateBox<Double> = stateStorage.storage(for: timeKey, default: clock.now())
         stateStorage.markActive(context.identity)
 
         // Start render-trigger task on first appearance.
@@ -283,11 +285,11 @@ private struct _SpinnerCore: View, Renderable {
             _ = lifecycle.recordAppear(token: token) {}
 
             let triggerNanos: UInt64 = 23_800_000  // ~24ms — matches run loop poll rate (~42 FPS)
-            lifecycle.startTask(token: token, priority: .medium) {
+            lifecycle.startTask(token: token, priority: .medium) { [invalidationSink] in
                 while !Task.isCancelled {
                     try? await Task.sleep(nanoseconds: triggerNanos)
                     guard !Task.isCancelled else { break }
-                    AppState.shared.setNeedsRender()
+                    invalidationSink?.invalidate(.renderOnly)
                 }
             }
         } else {
@@ -300,7 +302,7 @@ private struct _SpinnerCore: View, Renderable {
         }
 
         // Calculate frame index from elapsed time.
-        let elapsed = Date().timeIntervalSinceReferenceDate - startTimeBox.value
+        let elapsed = clock.now() - startTimeBox.value
         let frameCount: Int
         switch style {
         case .bouncing:

--- a/Sources/TUIkit/Views/_ImageCore.swift
+++ b/Sources/TUIkit/Views/_ImageCore.swift
@@ -63,6 +63,8 @@ struct _ImageCore: View, Renderable, Layoutable {
         let showSpinner = context.environment.imagePlaceholderSpinner
         let maxPixelCount = context.environment.imageMaxPixelCount
         let urlTimeout = context.environment.imageURLTimeout
+        let imageLoader = context.environment.imageLoader
+        let imageCache = context.environment.imageCache
 
         // Retrieve or create persistent phase state
         let phaseKey = StateStorage.StateKey(identity: identity, propertyIndex: StateIndex.phase)
@@ -84,18 +86,16 @@ struct _ImageCore: View, Renderable, Layoutable {
             _ = lifecycle.recordAppear(token: token) {}
 
             let src = source
-            lifecycle.startTask(token: token, priority: .userInitiated) {
-                let loader = PlatformImageLoader()
-
+            lifecycle.startTask(token: token, priority: .userInitiated) { [imageLoader, imageCache] in
                 do {
                     let rawImage: RGBAImage
                     switch src {
                     case .file(let path):
-                        rawImage = try loader.loadImage(from: path, maxPixelCount: maxPixelCount)
+                        rawImage = try imageLoader.loadImage(from: path, maxPixelCount: maxPixelCount)
                     case .url(let urlString):
-                        rawImage = try loader.loadImage(
+                        rawImage = try imageLoader.loadImage(
                             from: urlString,
-                            cache: .shared,
+                            cache: imageCache,
                             timeout: urlTimeout,
                             maxPixelCount: maxPixelCount
                         )

--- a/Sources/TUIkitCore/Rendering/ViewIdentity.swift
+++ b/Sources/TUIkitCore/Rendering/ViewIdentity.swift
@@ -33,7 +33,7 @@
 /// The identity is **stable across render passes** as long as the view tree
 /// structure does not change. If a `ConditionalView` switches branches, the
 /// old branch's state is invalidated.
-public struct ViewIdentity: Hashable, CustomStringConvertible {
+public struct ViewIdentity: Hashable, CustomStringConvertible, Sendable {
     /// The structural path from root to this view.
     ///
     /// Format: `"TypeA/TypeB.childIndex/TypeC"`

--- a/Sources/TUIkitExample/Pages/OverlaysPage.swift
+++ b/Sources/TUIkitExample/Pages/OverlaysPage.swift
@@ -79,7 +79,7 @@ private enum OverlayDemo: Int, CaseIterable {
         case .modalCustom:
             ".modal(isPresented: $show) { VStack { ... } }"
         case .notification:
-            "NotificationService.current.post(\"Saved!\")"
+            "@Environment(\\.notificationService) + notifications.post(\"Saved!\")"
         }
     }
 
@@ -97,6 +97,7 @@ private enum OverlayDemo: Int, CaseIterable {
 /// panel on the right. Pressing Enter shows the selected overlay
 /// with dimmed background content.
 struct OverlaysPage: View {
+    @Environment(\.notificationService) private var notifications
     @State var menuSelection: Int = 0
     @State var showOverlay: Bool = false
 
@@ -153,7 +154,7 @@ struct OverlaysPage: View {
                     selection: $menuSelection,
                     onSelect: { _ in
                         if selectedDemo.isNotification {
-                            NotificationService.current.post(
+                            notifications.post(
                                 "Operation completed successfully!"
                             )
                         } else {
@@ -175,7 +176,7 @@ struct OverlaysPage: View {
                     .foregroundStyle(.palette.foregroundSecondary)
                 Text("  .modal(isPresented:)        — for Dialog, custom content")
                     .foregroundStyle(.palette.foregroundSecondary)
-                Text("  NotificationService.current.post() — fire-and-forget with fade")
+                Text("  notifications.post()        — fire-and-forget with fade")
                     .foregroundStyle(.palette.foregroundSecondary)
                 Text("Modals dim the background. Notifications stay non-blocking.")
                     .bold()

--- a/Sources/TUIkitImage/ImageLoader.swift
+++ b/Sources/TUIkitImage/ImageLoader.swift
@@ -165,6 +165,40 @@ public protocol ImageLoader: Sendable {
     /// - Returns: The decoded image as `RGBAImage`.
     /// - Throws: `ImageLoadError` if the data cannot be decoded.
     func loadImage(from data: Data) throws -> RGBAImage
+
+    /// Loads an image from a file path with an optional pixel limit.
+    func loadImage(from path: String, maxPixelCount: Int?) throws -> RGBAImage
+
+    /// Loads an image from a URL using the supplied runtime cache.
+    func loadImage(
+        from urlString: String,
+        cache: URLImageCache,
+        timeout: TimeInterval,
+        maxPixelCount: Int?
+    ) throws -> RGBAImage
+}
+
+// MARK: - ImageLoader Defaults
+
+public extension ImageLoader {
+    func loadImage(from path: String, maxPixelCount: Int?) throws -> RGBAImage {
+        let image = try loadImage(from: path)
+        try validatePixelCount(image, maxPixelCount: maxPixelCount)
+        return image
+    }
+
+    func loadImage(
+        from urlString: String,
+        cache: URLImageCache,
+        timeout: TimeInterval,
+        maxPixelCount: Int?
+    ) throws -> RGBAImage {
+        if let image = cache.get(urlString) {
+            try validatePixelCount(image, maxPixelCount: maxPixelCount)
+            return image
+        }
+        throw ImageLoadError.downloadFailed("URL loading is not supported by this image loader")
+    }
 }
 
 // MARK: - ImageLoadError
@@ -327,13 +361,11 @@ private extension PlatformImageLoader {
 /// Cached entries persist for the lifetime of the application.
 /// Thread-safe via an internal lock.
 public final class URLImageCache: @unchecked Sendable {
-    /// Shared session cache.
-    public static let shared = URLImageCache()
-
     private var cache: [String: RGBAImage] = [:]
     private let lock = NSLock()
 
-    private init() {}
+    /// Creates an empty session cache.
+    public init() {}
 
     /// Returns a cached image for the given URL string, or nil.
     public func get(_ urlString: String) -> RGBAImage? {
@@ -347,6 +379,13 @@ public final class URLImageCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         cache[urlString] = image
+    }
+
+    /// Removes every cached image.
+    public func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        cache.removeAll()
     }
 }
 
@@ -368,7 +407,7 @@ extension PlatformImageLoader {
     /// - Throws: `ImageLoadError` on network or decoding failure, or if image exceeds size limit.
     public func loadImage(
         from urlString: String,
-        cache: URLImageCache = .shared,
+        cache: URLImageCache,
         timeout: TimeInterval = 30,
         maxPixelCount: Int? = nil
     ) throws -> RGBAImage {
@@ -398,5 +437,18 @@ extension PlatformImageLoader {
         let image = try loadImage(from: data, maxPixelCount: maxPixelCount)
         cache.set(urlString, image: image)
         return image
+    }
+}
+
+// MARK: - Pixel Limit Validation
+
+private func validatePixelCount(_ image: RGBAImage, maxPixelCount: Int?) throws {
+    guard let maxPixelCount else { return }
+    let (pixelCount, overflow) = image.width.multipliedReportingOverflow(by: image.height)
+    guard !overflow else {
+        throw ImageLoadError.sizeOverflow(width: image.width, height: image.height)
+    }
+    guard pixelCount <= maxPixelCount else {
+        throw ImageLoadError.imageTooLarge(pixelCount: pixelCount, limit: maxPixelCount)
     }
 }

--- a/Sources/TUIkitView/Environment/ViewServiceEnvironment.swift
+++ b/Sources/TUIkitView/Environment/ViewServiceEnvironment.swift
@@ -20,6 +20,13 @@ private struct RenderCacheKey: EnvironmentKey {
     static let defaultValue: RenderCache? = nil
 }
 
+// MARK: - Render Invalidation
+
+/// EnvironmentKey for routing state changes to the owning runtime.
+private struct RenderInvalidationSinkKey: EnvironmentKey {
+    static let defaultValue: (any RenderInvalidationSink)? = nil
+}
+
 // MARK: - EnvironmentValues Extensions
 
 extension EnvironmentValues {
@@ -34,5 +41,11 @@ extension EnvironmentValues {
     public var renderCache: RenderCache? {
         get { self[RenderCacheKey.self] }
         set { self[RenderCacheKey.self] = newValue }
+    }
+
+    /// Sink that routes state changes to the runtime owning this render tree.
+    public var renderInvalidationSink: (any RenderInvalidationSink)? {
+        get { self[RenderInvalidationSinkKey.self] }
+        set { self[RenderInvalidationSinkKey.self] = newValue }
     }
 }

--- a/Sources/TUIkitView/Rendering/RenderCache.swift
+++ b/Sources/TUIkitView/Rendering/RenderCache.swift
@@ -145,9 +145,6 @@ public final class RenderCache: @unchecked Sendable {
     /// Stats snapshot taken at the start of each render pass (for per-frame deltas).
     private var statsAtFrameStart = Stats()
 
-    /// The global shared instance.
-    public static let shared = RenderCache()
-
     /// Whether debug logging is enabled via the `TUIKIT_DEBUG_RENDER` environment variable.
     public static let debugEnabled: Bool = {
         ProcessInfo.processInfo.environment["TUIKIT_DEBUG_RENDER"] == "1"

--- a/Sources/TUIkitView/Rendering/RenderInvalidation.swift
+++ b/Sources/TUIkitView/Rendering/RenderInvalidation.swift
@@ -1,0 +1,33 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  RenderInvalidation.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+import TUIkitCore
+
+// MARK: - Render Invalidation
+
+/// Describes the rendering work requested by a state producer.
+public enum RenderInvalidation: Sendable {
+    /// Requests another frame without invalidating memoized view output.
+    case renderOnly
+
+    /// Invalidates cached output associated with one view subtree.
+    case subtree(ViewIdentity)
+
+    /// Invalidates every cached subtree before the next frame.
+    case all
+}
+
+// MARK: - Render Invalidation Sink
+
+/// Lower-module boundary for routing changes to the owning render runtime.
+///
+/// State producers depend on this protocol instead of reaching upward to an
+/// application runtime or global service. Implementations must be thread-safe
+/// because async view work may request invalidation from a background task.
+public protocol RenderInvalidationSink: AnyObject, Sendable {
+    /// Requests a render operation from the owning runtime.
+    func invalidate(_ invalidation: RenderInvalidation)
+}

--- a/Sources/TUIkitView/Rendering/Renderable.swift
+++ b/Sources/TUIkitView/Rendering/Renderable.swift
@@ -176,6 +176,7 @@ public func renderToBuffer<V: View>(_ view: V, context: RenderContext) -> FrameB
     // that will be constructed inside this view's body.
     if V.Body.self != Never.self {
         let childContext = context.withChildIdentity(type: V.Body.self)
+        let invalidationSink = context.environment.renderInvalidationSink
 
         // Wrap body evaluation in observation tracking so that any @Observable
         // property accessed during body triggers a re-render when mutated.
@@ -183,11 +184,11 @@ public func renderToBuffer<V: View>(_ view: V, context: RenderContext) -> FrameB
             withObservationTracking {
                 view.body
             } onChange: {
-                AppState.shared.setNeedsRenderWithCacheClear()
+                invalidationSink?.invalidate(.all)
             }
         }
 
-        context.environment.stateStorage!.markActive(context.identity)
+        context.environment.stateStorage?.markActive(context.identity)
 
         return renderToBuffer(body, context: childContext)
     }

--- a/Sources/TUIkitView/State/State.swift
+++ b/Sources/TUIkitView/State/State.swift
@@ -23,9 +23,6 @@ import TUIkitCore
 ///   management in your views. Direct use of `AppState` is only necessary in advanced scenarios
 ///   where you manage state outside the view hierarchy.
 public final class AppState: Sendable {
-    /// Legacy process-wide render state used by services awaiting runtime injection.
-    public static let shared = AppState()
-
     /// Internal state protected by a lock.
     private struct StateData: Sendable {
         var needsRender = false

--- a/Sources/TUIkitView/State/State.swift
+++ b/Sources/TUIkitView/State/State.swift
@@ -16,20 +16,21 @@ import TUIkitCore
 /// by an `NSLock`.
 ///
 /// The `AppRunner` subscribes to state changes and re-renders when notified.
-/// Property wrappers like ``State`` and ``AppStorage`` access the shared instance
-/// via ``AppState/shared``.
+/// Property wrappers route changes to the runtime-owned instance through
+/// ``RenderInvalidationSink``.
 ///
 /// - Important: This is framework infrastructure. Prefer using ``State`` for reactive state
 ///   management in your views. Direct use of `AppState` is only necessary in advanced scenarios
 ///   where you manage state outside the view hierarchy.
 public final class AppState: Sendable {
-    /// The global shared instance.
+    /// Legacy process-wide render state used by services awaiting runtime injection.
     public static let shared = AppState()
 
     /// Internal state protected by a lock.
     private struct StateData: Sendable {
         var needsRender = false
-        var needsCacheClear = false
+        var invalidatesAllCachedOutput = false
+        var invalidatedSubtrees: Set<ViewIdentity> = []
         var observers: [@Sendable () -> Void] = []
     }
 
@@ -52,14 +53,7 @@ public extension AppState {
     /// automatically detects environment changes via `EnvironmentSnapshot`
     /// comparison and clears the cache when needed.
     func setNeedsRender() {
-        let observers = lock.withLock { state -> [@Sendable () -> Void] in
-            state.needsRender = true
-            return state.observers
-        }
-        // Call observers outside the lock to avoid potential deadlocks
-        for observer in observers {
-            observer()
-        }
+        invalidate(.renderOnly)
     }
 
     /// Marks state as changed and requests a full cache clear on next render.
@@ -71,14 +65,7 @@ public extension AppState {
     ///
     /// Thread-safe: can be called from any thread.
     func setNeedsRenderWithCacheClear() {
-        let observers = lock.withLock { state -> [@Sendable () -> Void] in
-            state.needsRender = true
-            state.needsCacheClear = true
-            return state.observers
-        }
-        for observer in observers {
-            observer()
-        }
+        invalidate(.all)
     }
 }
 
@@ -113,16 +100,75 @@ extension AppState {
         }
     }
 
-    /// Consumes and returns the cache-clear flag.
+    /// Consumes pending cache invalidations.
     ///
     /// Called by the render loop at the start of each frame. Returns `true`
-    /// if any `@Observable` property changed since the last render, signaling
-    /// that the render cache should be fully cleared.
-    public func consumeNeedsCacheClear() -> Bool {
+    /// The returned invalidations are applied by the owning runtime on the
+    /// main actor before rendering. Render-only requests are represented by
+    /// an empty array because they do not affect cached output.
+    public func consumePendingCacheInvalidations() -> [RenderInvalidation] {
         lock.withLock { state in
-            let value = state.needsCacheClear
-            state.needsCacheClear = false
-            return value
+            if state.invalidatesAllCachedOutput {
+                state.invalidatesAllCachedOutput = false
+                state.invalidatedSubtrees.removeAll(keepingCapacity: true)
+                return [.all]
+            }
+
+            let invalidations = state.invalidatedSubtrees.map(RenderInvalidation.subtree)
+            state.invalidatedSubtrees.removeAll(keepingCapacity: true)
+            return invalidations
+        }
+    }
+
+    /// Consumes pending invalidations and reports whether a full cache clear was requested.
+    ///
+    /// Prefer ``consumePendingCacheInvalidations()`` when subtree invalidations
+    /// must be preserved.
+    public func consumeNeedsCacheClear() -> Bool {
+        consumePendingCacheInvalidations().contains { invalidation in
+            if case .all = invalidation {
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Clears render flags, pending invalidations, and observers.
+    public func reset() {
+        lock.withLock { state in
+            state.needsRender = false
+            state.invalidatesAllCachedOutput = false
+            state.invalidatedSubtrees.removeAll()
+            state.observers.removeAll()
+        }
+    }
+}
+
+// MARK: - Render Invalidation Sink
+
+extension AppState: RenderInvalidationSink {
+    public func invalidate(_ invalidation: RenderInvalidation) {
+        let observers = lock.withLock { state -> [@Sendable () -> Void] in
+            state.needsRender = true
+
+            switch invalidation {
+            case .renderOnly:
+                break
+            case .subtree(let identity):
+                if !state.invalidatesAllCachedOutput {
+                    state.invalidatedSubtrees.insert(identity)
+                }
+            case .all:
+                state.invalidatesAllCachedOutput = true
+                state.invalidatedSubtrees.removeAll(keepingCapacity: true)
+            }
+
+            return state.observers
+        }
+
+        // Call observers outside the lock to avoid potential deadlocks.
+        for observer in observers {
+            observer()
         }
     }
 }
@@ -141,10 +187,18 @@ public struct HydrationContext {
     /// The persistent state storage.
     public let storage: StateStorage
 
+    /// The runtime that owns state created in this context.
+    public let invalidationSink: (any RenderInvalidationSink)?
+
     /// Creates a new hydration context.
-    public init(identity: ViewIdentity, storage: StateStorage) {
+    public init(
+        identity: ViewIdentity,
+        storage: StateStorage,
+        invalidationSink: (any RenderInvalidationSink)? = nil
+    ) {
         self.identity = identity
         self.storage = storage
+        self.invalidationSink = invalidationSink
     }
 }
 
@@ -195,10 +249,13 @@ public enum StateRegistration {
         let previousCounter = counter
         let previousEnvironment = activeEnvironment
 
-        activeContext = HydrationContext(
-            identity: context.identity,
-            storage: context.environment.stateStorage!
-        )
+        activeContext = context.environment.stateStorage.map {
+            HydrationContext(
+                identity: context.identity,
+                storage: $0,
+                invalidationSink: context.environment.renderInvalidationSink
+            )
+        }
         counter = 0
         activeEnvironment = context.environment
 
@@ -313,7 +370,7 @@ public struct Binding<Value> {
 /// State is keyed by `ViewIdentity` and property index, ensuring values
 /// survive view reconstruction across render passes.
 ///
-/// Mutations signal re-renders through `AppState.shared`.
+/// Mutations signal re-renders through the owning runtime's invalidation sink.
 @propertyWrapper
 public struct State<Value> {
     /// The backing storage box for this state value.
@@ -331,13 +388,20 @@ public struct State<Value> {
 
     /// The current state value.
     public var wrappedValue: Value {
-        get { box.value }
-        nonmutating set { box.value = newValue }
+        get {
+            bindToActiveRuntime()
+            return box.value
+        }
+        nonmutating set {
+            bindToActiveRuntime()
+            box.value = newValue
+        }
     }
 
     /// A binding to the state value.
     public var projectedValue: Binding<Value> {
-        Binding(
+        bindToActiveRuntime()
+        return Binding(
             get: { self.box.value },
             set: { self.box.value = $0 }
         )
@@ -359,8 +423,18 @@ public struct State<Value> {
             StateRegistration.counter += 1
             let key = StateStorage.StateKey(identity: context.identity, propertyIndex: index)
             self.box = context.storage.storage(for: key, default: wrappedValue)
+            self.box.bind(identity: context.identity, invalidationSink: context.invalidationSink)
         } else {
             self.box = StateBox(wrappedValue)
         }
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension State {
+    func bindToActiveRuntime() {
+        guard let context = StateRegistration.activeContext else { return }
+        box.bind(identity: context.identity, invalidationSink: context.invalidationSink)
     }
 }

--- a/Sources/TUIkitView/State/StateStorage.swift
+++ b/Sources/TUIkitView/State/StateStorage.swift
@@ -68,8 +68,15 @@ public final class StateStorage: @unchecked Sendable {
     /// Identities seen during the current render pass (for garbage collection).
     private var activeIdentities: Set<ViewIdentity> = []
 
+    /// Runtime receiving invalidations from state boxes created by this storage.
+    private var invalidationSink: (any RenderInvalidationSink)?
+
     /// Creates an empty state storage.
-    public init() {}
+    ///
+    /// - Parameter invalidationSink: Runtime that owns values stored here.
+    public init(invalidationSink: (any RenderInvalidationSink)? = nil) {
+        self.invalidationSink = invalidationSink
+    }
 
     /// The number of stored state entries (for testing/debugging).
     public var count: Int { values.count }
@@ -90,13 +97,24 @@ extension StateStorage {
     /// - Returns: The persistent `Storage` object for this property.
     public func storage<Value>(for key: StateKey, default defaultValue: Value) -> StateBox<Value> {
         if let existing = values[key] as? StateBox<Value> {
-            existing.identity = key.identity
+            existing.bind(identity: key.identity, invalidationSink: invalidationSink)
             return existing
         }
-        let fresh = StateBox(defaultValue)
-        fresh.identity = key.identity
+        let fresh = StateBox(
+            defaultValue,
+            identity: key.identity,
+            invalidationSink: invalidationSink
+        )
         values[key] = fresh
         return fresh
+    }
+
+    /// Assigns the runtime that owns subsequently retrieved state boxes.
+    ///
+    /// TUIContext calls this while assembling injected services, before a
+    /// render pass can create state.
+    public func setInvalidationSink(_ invalidationSink: (any RenderInvalidationSink)?) {
+        self.invalidationSink = invalidationSink
     }
 
     /// Marks an identity as active during the current render pass.
@@ -199,7 +217,7 @@ extension StateStorage {
 /// It is a reference type so that mutations are visible across all copies
 /// of the `@State` struct (which uses `nonmutating set`).
 ///
-/// On value change, signals a re-render through `AppState.shared`.
+/// On value change, signals a re-render through its owning runtime.
 /// Cache invalidation is identity-aware: only the affected subtree is
 /// cleared instead of the entire cache.
 public final class StateBox<Value>: @unchecked Sendable {
@@ -207,24 +225,49 @@ public final class StateBox<Value>: @unchecked Sendable {
     ///
     /// Set during hydration from ``StateStorage``. Used for targeted
     /// cache invalidation via ``RenderCache/clearAffected(by:)``.
-    var identity: ViewIdentity?
+    private var identity: ViewIdentity?
+
+    /// Runtime receiving invalidations when the value changes.
+    private var invalidationSink: (any RenderInvalidationSink)?
 
     /// The current value.
     public var value: Value {
         didSet {
+            guard let invalidationSink else { return }
             if let identity {
-                RenderCache.shared.clearAffected(by: identity)
+                invalidationSink.invalidate(.subtree(identity))
             } else {
-                RenderCache.shared.clearAll()
+                invalidationSink.invalidate(.all)
             }
-            AppState.shared.setNeedsRender()
         }
     }
 
     /// Creates a state box with an initial value.
     ///
-    /// - Parameter value: The initial value.
-    public init(_ value: Value) {
+    /// - Parameters:
+    ///   - value: The initial value.
+    ///   - identity: The identity owning this value, if known.
+    ///   - invalidationSink: Runtime receiving invalidations.
+    public init(
+        _ value: Value,
+        identity: ViewIdentity? = nil,
+        invalidationSink: (any RenderInvalidationSink)? = nil
+    ) {
         self.value = value
+        self.identity = identity
+        self.invalidationSink = invalidationSink
+    }
+}
+
+// MARK: - Internal API
+
+extension StateBox {
+    /// Associates this box with the runtime and identity owning it.
+    func bind(
+        identity: ViewIdentity,
+        invalidationSink: (any RenderInvalidationSink)?
+    ) {
+        self.identity = identity
+        self.invalidationSink = invalidationSink
     }
 }

--- a/Tests/TUIkitTests/ImageURLLoadingTests.swift
+++ b/Tests/TUIkitTests/ImageURLLoadingTests.swift
@@ -22,13 +22,14 @@ struct ImageURLLoadingTests {
             height: 2,
             pixels: [RGBA](repeating: RGBA(r: 0, g: 0, b: 0), count: 4)
         )
-        URLImageCache.shared.set(urlString, image: cachedImage)
+        let cache = URLImageCache()
+        cache.set(urlString, image: cachedImage)
         let loader = PlatformImageLoader(
             limits: ImageDecodingLimits(maxPixelCount: 3)
         )
 
         do {
-            _ = try loader.loadImage(from: urlString, cache: .shared)
+            _ = try loader.loadImage(from: urlString, cache: cache)
             Issue.record("Expected the current loader limit to reject the cached image")
         } catch let error as ImageLoadError {
             guard case .imageTooLarge(pixelCount: 4, limit: 3) = error else {

--- a/Tests/TUIkitTests/NavigationSplitViewTests.swift
+++ b/Tests/TUIkitTests/NavigationSplitViewTests.swift
@@ -328,8 +328,7 @@ struct NavigationSplitViewFocusSectionTests {
     @Test("Two-column split view registers two focus sections")
     func twoColumnRegistersTwoFocusSections() {
         let focusManager = FocusManager()
-        var environment = EnvironmentValues()
-        environment.focusManager = focusManager
+        let tuiContext = TUIContext(focusManager: focusManager)
 
         let splitView = NavigationSplitView {
             Text("Sidebar")
@@ -340,8 +339,7 @@ struct NavigationSplitViewFocusSectionTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(splitView, context: context)
@@ -354,8 +352,7 @@ struct NavigationSplitViewFocusSectionTests {
     @Test("Three-column split view registers three focus sections")
     func threeColumnRegistersThreeFocusSections() {
         let focusManager = FocusManager()
-        var environment = EnvironmentValues()
-        environment.focusManager = focusManager
+        let tuiContext = TUIContext(focusManager: focusManager)
 
         let splitView = NavigationSplitView {
             Text("Sidebar")
@@ -368,8 +365,7 @@ struct NavigationSplitViewFocusSectionTests {
         let context = RenderContext(
             availableWidth: 100,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(splitView, context: context)
@@ -383,8 +379,7 @@ struct NavigationSplitViewFocusSectionTests {
     @Test("Hidden columns do not register focus sections")
     func hiddenColumnsNoFocusSections() {
         let focusManager = FocusManager()
-        var environment = EnvironmentValues()
-        environment.focusManager = focusManager
+        let tuiContext = TUIContext(focusManager: focusManager)
 
         var visibility = NavigationSplitViewVisibility.detailOnly
         let binding = Binding(get: { visibility }, set: { visibility = $0 })
@@ -398,8 +393,7 @@ struct NavigationSplitViewFocusSectionTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(splitView, context: context)

--- a/Tests/TUIkitTests/NotificationModifierTests.swift
+++ b/Tests/TUIkitTests/NotificationModifierTests.swift
@@ -149,12 +149,17 @@ struct NotificationTests {
 
     @Test("Expired entries are pruned by activeEntries")
     func expiredEntriesPruned() {
-        let service = NotificationService()
-        // Post with a very short duration so it expires almost immediately.
+        let timeSource = NotificationTestTimeSource(now: 100)
+        let service = NotificationService(
+            clock: RuntimeClock { timeSource.now },
+            invalidationSink: nil
+        )
         service.post("Quick", duration: 0.0)
+        #expect(service.activeEntries().count == 1)
 
-        // Wait slightly longer than fade-in + fade-out.
-        Thread.sleep(forTimeInterval: NotificationTiming.fadeInDuration + NotificationTiming.fadeOutDuration + 0.05)
+        timeSource.advance(
+            by: NotificationTiming.fadeInDuration + NotificationTiming.fadeOutDuration + 0.01
+        )
 
         let entries = service.activeEntries()
         #expect(entries.isEmpty)
@@ -229,5 +234,26 @@ struct NotificationTests {
         #expect(joined.contains("Second"))
         // Both notifications should be in the buffer, stacked.
         #expect(buffer.height > 3)
+    }
+}
+
+private final class NotificationTestTimeSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentTime: TimeInterval
+
+    init(now: TimeInterval) {
+        self.currentTime = now
+    }
+
+    var now: TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentTime
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        currentTime += interval
+        lock.unlock()
     }
 }

--- a/Tests/TUIkitTests/RuntimeCharacterizationTests.swift
+++ b/Tests/TUIkitTests/RuntimeCharacterizationTests.swift
@@ -200,18 +200,12 @@ struct RuntimeCharacterizationTests {
         }
     }
 
-    @Test("Default render-cache crosstalk remains characterized for issue #8")
-    func knownDefaultRenderCacheCrosstalkDefect() {
+    @Test("Default runtime render caches are isolated")
+    func defaultRuntimeRenderCachesAreIsolated() {
         let firstContext = TUIContext()
         let secondContext = TUIContext()
-        let cachesAreIsolated = firstContext.renderCache !== secondContext.renderCache
 
-        withKnownIssue("Issue #8: default TUIContext instances share one render cache") {
-            #expect(cachesAreIsolated)
-        } matching: { issue in
-            guard case .expectationFailed = issue.kind else { return false }
-            return true
-        }
+        #expect(firstContext.renderCache !== secondContext.renderCache)
     }
 
     @Test("Cached descendant lifecycle loss remains characterized for issue #14")

--- a/Tests/TUIkitTests/StatePropertyTests.swift
+++ b/Tests/TUIkitTests/StatePropertyTests.swift
@@ -28,16 +28,18 @@ struct StatePropertyWrapperTests {
         #expect(state.wrappedValue == 10)
     }
 
-    @Test("State mutation triggers render via AppState.shared")
+    @Test("State box mutation triggers its injected runtime")
     func stateTriggerRender() {
-        // StateBox.didSet calls AppState.shared.setNeedsRender().
-        // We mutate and check that the shared instance is marked as needing render.
-        let state = State(wrappedValue: "initial")
-        state.wrappedValue = "changed"
-        let triggered = AppState.shared.needsRender
-        // Reset for other tests
-        AppState.shared.didRender()
-        #expect(triggered == true)
+        let appState = AppState()
+        let box = StateBox(
+            "initial",
+            identity: ViewIdentity(path: "state"),
+            invalidationSink: appState
+        )
+
+        box.value = "changed"
+
+        #expect(appState.needsRender)
     }
 
     @Test("Binding from State updates original")

--- a/Tests/TUIkitTests/StateStorageIdentityTests.swift
+++ b/Tests/TUIkitTests/StateStorageIdentityTests.swift
@@ -15,9 +15,8 @@ struct StateStorageIdentityTests {
 
     /// Creates a fresh StateStorage for test isolation.
     ///
-    /// State mutations during tests call `setNeedsRender()` on the shared
-    /// `AppState.shared` instance — that's harmless and avoids race
-    /// conditions with parallel suites.
+    /// No invalidation sink is attached because these tests exercise storage
+    /// identity without a running application runtime.
     private func testStorage() -> StateStorage {
         StateStorage()
     }

--- a/Tests/TUIkitTests/StatusBarViewTests.swift
+++ b/Tests/TUIkitTests/StatusBarViewTests.swift
@@ -217,11 +217,10 @@ struct StatusBarItemsModifierTests {
 
     @Test("statusBarItems modifier sets items in environment")
     func modifierSetsItemsInEnvironment() {
-        // Setup: Create a status bar state and environment
-        let state = StatusBarState()
+        // Setup: Create a status bar state owned by the runtime
+        let tuiContext = TUIContext()
+        let state = tuiContext.statusBar
         state.showSystemItems = false  // Disable for cleaner test
-        var environment = EnvironmentValues()
-        environment.statusBar = state
 
         // Create view with modifier
         let view = Text("Test")
@@ -233,8 +232,7 @@ struct StatusBarItemsModifierTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(view, context: context)
@@ -247,10 +245,9 @@ struct StatusBarItemsModifierTests {
     @Test("statusBarItems modifier with context pushes to stack")
     func modifierWithContextPushesToStack() {
         // Setup
-        let state = StatusBarState()
+        let tuiContext = TUIContext()
+        let state = tuiContext.statusBar
         state.showSystemItems = false  // Disable for cleaner test
-        var environment = EnvironmentValues()
-        environment.statusBar = state
 
         // Set global items first
         state.setItems([
@@ -267,8 +264,7 @@ struct StatusBarItemsModifierTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(view, context: context)
@@ -287,9 +283,7 @@ struct StatusBarItemsModifierTests {
 
     @Test("statusBarItems modifier renders content")
     func modifierRendersContent() {
-        let state = StatusBarState()
-        var environment = EnvironmentValues()
-        environment.statusBar = state
+        let tuiContext = TUIContext()
 
         let view = Text("Hello World")
             .statusBarItems {
@@ -299,8 +293,7 @@ struct StatusBarItemsModifierTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         let buffer = renderToBuffer(view, context: context)
@@ -312,10 +305,9 @@ struct StatusBarItemsModifierTests {
 
     @Test("Nested statusBarItems modifiers")
     func nestedModifiers() {
-        let state = StatusBarState()
+        let tuiContext = TUIContext()
+        let state = tuiContext.statusBar
         state.showSystemItems = false  // Disable for cleaner test
-        var environment = EnvironmentValues()
-        environment.statusBar = state
 
         // Outer sets global, inner pushes context
         let innerView = Text("Inner")
@@ -333,8 +325,7 @@ struct StatusBarItemsModifierTests {
         let context = RenderContext(
             availableWidth: 80,
             availableHeight: 24,
-            environment: environment,
-            tuiContext: TUIContext()
+            tuiContext: tuiContext
         )
 
         _ = renderToBuffer(outerView, context: context)

--- a/Tests/TUIkitTests/TUIContextTests.swift
+++ b/Tests/TUIkitTests/TUIContextTests.swift
@@ -116,6 +116,165 @@ struct TUIContextTests {
         #expect(firstContext.renderCache.stats.clears == 1)
         #expect(secondContext.renderCache.stats.clears == 0)
     }
+
+    @Test("Application services are isolated per runtime")
+    func applicationServicesAreIsolatedPerRuntime() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+
+        #expect(firstContext.localizationService !== secondContext.localizationService)
+        #expect(firstContext.notificationService !== secondContext.notificationService)
+        #expect(firstContext.focusManager !== secondContext.focusManager)
+        #expect(firstContext.paletteManager !== secondContext.paletteManager)
+        #expect(firstContext.appearanceManager !== secondContext.appearanceManager)
+        #expect(firstContext.statusBar !== secondContext.statusBar)
+        #expect(firstContext.appHeader !== secondContext.appHeader)
+
+        firstContext.localizationService.setLanguage(.german)
+        firstContext.notificationService.post("first")
+        firstContext.storageBackend.setValue("first", forKey: "runtime")
+        let secondStoredValue: String? = secondContext.storageBackend.value(forKey: "runtime")
+
+        #expect(firstContext.localizationService.currentLanguage == .german)
+        #expect(secondContext.localizationService.currentLanguage == .english)
+        #expect(firstContext.notificationService.activeEntries().map(\.message) == ["first"])
+        #expect(secondContext.notificationService.activeEntries().isEmpty)
+        #expect(secondStoredValue == nil)
+    }
+
+    @Test("Runtime services invalidate only their owning runtime")
+    func runtimeServicesInvalidateOnlyTheirOwningRuntime() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+
+        func resetInvalidationState() {
+            firstContext.applyPendingRenderInvalidations()
+            secondContext.applyPendingRenderInvalidations()
+            firstContext.appState.didRender()
+            secondContext.appState.didRender()
+        }
+
+        func expectOnlyFirstContextNeedsRender() {
+            #expect(firstContext.appState.needsRender)
+            #expect(secondContext.appState.needsRender == false)
+        }
+
+        resetInvalidationState()
+        firstContext.localizationService.setLanguage(.german)
+        expectOnlyFirstContextNeedsRender()
+
+        resetInvalidationState()
+        firstContext.notificationService.post("first")
+        expectOnlyFirstContextNeedsRender()
+
+        resetInvalidationState()
+        firstContext.paletteManager.cycleNext()
+        expectOnlyFirstContextNeedsRender()
+
+        resetInvalidationState()
+        firstContext.appearanceManager.cycleNext()
+        expectOnlyFirstContextNeedsRender()
+
+        resetInvalidationState()
+        firstContext.statusBar.setItems([])
+        expectOnlyFirstContextNeedsRender()
+    }
+
+    @Test("Focus changes invalidate only the owning runtime")
+    func focusChangesInvalidateOnlyOwningRuntime() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+
+        firstContext.appState.didRender()
+        secondContext.appState.didRender()
+        firstContext.focusManager.register(MockFocusable(id: "first"))
+
+        #expect(firstContext.appState.needsRender)
+        #expect(secondContext.appState.needsRender == false)
+        #expect(firstContext.focusManager.currentFocusedID == "first")
+        #expect(secondContext.focusManager.currentFocusedID == nil)
+    }
+
+    @Test("AppStorage binds to the owning runtime")
+    func appStorageBindsToOwningRuntime() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+        let firstStorage = AppStorage(wrappedValue: "default", "runtime-key")
+        let secondStorage = AppStorage(wrappedValue: "default", "runtime-key")
+        let firstRenderContext = RenderContext(
+            availableWidth: 20,
+            availableHeight: 1,
+            tuiContext: firstContext,
+            identity: ViewIdentity(path: "first")
+        )
+        let secondRenderContext = RenderContext(
+            availableWidth: 20,
+            availableHeight: 1,
+            tuiContext: secondContext,
+            identity: ViewIdentity(path: "second")
+        )
+
+        firstContext.appState.didRender()
+        secondContext.appState.didRender()
+        StateRegistration.withHydration(context: firstRenderContext) {
+            firstStorage.wrappedValue = "first"
+        }
+
+        let firstPersistedValue: String? = firstContext.storageBackend.value(forKey: "runtime-key")
+        let secondPersistedValue: String? = secondContext.storageBackend.value(forKey: "runtime-key")
+        #expect(firstPersistedValue == "first")
+        #expect(secondPersistedValue == nil)
+        #expect(firstContext.appState.needsRender)
+        #expect(secondContext.appState.needsRender == false)
+
+        firstContext.applyPendingRenderInvalidations()
+        firstContext.appState.didRender()
+        StateRegistration.withHydration(context: secondRenderContext) {
+            secondStorage.wrappedValue = "second"
+        }
+
+        let firstValue = StateRegistration.withHydration(context: firstRenderContext) {
+            firstStorage.wrappedValue
+        }
+        let secondValue = StateRegistration.withHydration(context: secondRenderContext) {
+            secondStorage.wrappedValue
+        }
+        #expect(firstValue == "first")
+        #expect(secondValue == "second")
+        #expect(firstContext.appState.needsRender == false)
+        #expect(secondContext.appState.needsRender)
+    }
+
+    @Test("Render context receives the complete owning runtime")
+    func renderContextReceivesCompleteOwningRuntime() {
+        let storageBackend = VolatileStorageBackend()
+        let tuiContext = TUIContext(
+            storageBackend: storageBackend,
+            clock: RuntimeClock { 42 }
+        )
+        let renderContext = RenderContext(
+            availableWidth: 80,
+            availableHeight: 24,
+            tuiContext: tuiContext
+        )
+
+        #expect(renderContext.environment.stateStorage === tuiContext.stateStorage)
+        #expect(renderContext.environment.lifecycle === tuiContext.lifecycle)
+        #expect(renderContext.environment.keyEventDispatcher === tuiContext.keyEventDispatcher)
+        #expect(renderContext.environment.renderCache === tuiContext.renderCache)
+        #expect(renderContext.environment.renderInvalidationSink === tuiContext.appState)
+        #expect(renderContext.environment.preferenceStorage === tuiContext.preferences)
+        #expect(renderContext.environment.localizationService === tuiContext.localizationService)
+        #expect(renderContext.environment.notificationService === tuiContext.notificationService)
+        #expect(renderContext.environment.focusManager === tuiContext.focusManager)
+        #expect(renderContext.environment.paletteManager === tuiContext.paletteManager)
+        #expect(renderContext.environment.appearanceManager === tuiContext.appearanceManager)
+        #expect(renderContext.environment.statusBar === tuiContext.statusBar)
+        #expect(renderContext.environment.appHeader === tuiContext.appHeader)
+        let environmentStorage = renderContext.environment.storageBackend as? VolatileStorageBackend
+        #expect(environmentStorage === storageBackend)
+        #expect(renderContext.environment.runtimeClock.now() == 42)
+    }
 }
 
 /// Test preference key for TUIContext tests.

--- a/Tests/TUIkitTests/TUIContextTests.swift
+++ b/Tests/TUIkitTests/TUIContextTests.swift
@@ -4,6 +4,7 @@
 //  Created by LAYERED.work
 //  License: MIT
 
+import Observation
 import Testing
 
 @testable import TUIkit
@@ -53,9 +54,84 @@ struct TUIContextTests {
         context.keyEventDispatcher.dispatch(KeyEvent(key: .enter))
         #expect(handled == true)
     }
+
+    @Test("State mutation invalidates only its owning runtime")
+    func stateMutationInvalidatesOnlyOwner() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+        let key = StateStorage.StateKey(
+            identity: ViewIdentity(path: "owner"),
+            propertyIndex: 0
+        )
+        let firstBox: StateBox<Int> = firstContext.stateStorage.storage(for: key, default: 0)
+        let secondBox: StateBox<Int> = secondContext.stateStorage.storage(for: key, default: 0)
+
+        firstContext.appState.didRender()
+        secondContext.appState.didRender()
+        firstBox.value = 1
+
+        #expect(firstContext.appState.needsRender)
+        #expect(secondContext.appState.needsRender == false)
+        #expect(secondBox.value == 0)
+
+        firstContext.applyPendingRenderInvalidations()
+
+        #expect(firstContext.renderCache.stats.subtreeClears == 1)
+        #expect(secondContext.renderCache.stats.subtreeClears == 0)
+    }
+
+    @Test("Observation invalidates only its rendering runtime")
+    func observationInvalidatesOnlyRenderingRuntime() {
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+        let firstModel = RuntimeObservationModel()
+        let secondModel = RuntimeObservationModel()
+
+        _ = renderToBuffer(
+            RuntimeObservationView(model: firstModel),
+            context: RenderContext(
+                availableWidth: 20,
+                availableHeight: 1,
+                tuiContext: firstContext
+            )
+        )
+        _ = renderToBuffer(
+            RuntimeObservationView(model: secondModel),
+            context: RenderContext(
+                availableWidth: 20,
+                availableHeight: 1,
+                tuiContext: secondContext
+            )
+        )
+
+        firstContext.appState.didRender()
+        secondContext.appState.didRender()
+        firstModel.value = 1
+
+        #expect(firstContext.appState.needsRender)
+        #expect(secondContext.appState.needsRender == false)
+
+        firstContext.applyPendingRenderInvalidations()
+
+        #expect(firstContext.renderCache.stats.clears == 1)
+        #expect(secondContext.renderCache.stats.clears == 0)
+    }
 }
 
 /// Test preference key for TUIContext tests.
 private struct TestContextStringKey: PreferenceKey {
     static let defaultValue: String = "default"
+}
+
+@Observable
+private final class RuntimeObservationModel {
+    var value = 0
+}
+
+private struct RuntimeObservationView: View {
+    let model: RuntimeObservationModel
+
+    var body: some View {
+        Text("value:\(model.value)")
+    }
 }

--- a/Tests/TUIkitTests/TUIContextTests.swift
+++ b/Tests/TUIkitTests/TUIContextTests.swift
@@ -4,6 +4,7 @@
 //  Created by LAYERED.work
 //  License: MIT
 
+import Foundation
 import Observation
 import Testing
 
@@ -245,6 +246,58 @@ struct TUIContextTests {
         #expect(secondContext.appState.needsRender)
     }
 
+    @Test("Image requests and caches are isolated per runtime")
+    func imageRequestsAndCachesAreIsolatedPerRuntime() async {
+        let firstLoader = RecordingRuntimeImageLoader()
+        let secondLoader = RecordingRuntimeImageLoader()
+        let firstCache = URLImageCache()
+        let secondCache = URLImageCache()
+        let firstContext = TUIContext(
+            imageLoader: firstLoader,
+            imageCache: firstCache
+        )
+        let secondContext = TUIContext(
+            imageLoader: secondLoader,
+            imageCache: secondCache
+        )
+        let url = "https://runtime.test/image.png"
+        let image = Image(.url(url)).imagePlaceholderSpinner(false)
+
+        _ = renderToBuffer(
+            image,
+            context: RenderContext(
+                availableWidth: 4,
+                availableHeight: 2,
+                tuiContext: firstContext,
+                identity: ViewIdentity(path: "image")
+            )
+        )
+        #expect(await waitForRequest(in: firstLoader))
+        #expect(firstLoader.requestedURLs == [url])
+        #expect(secondLoader.requestedURLs.isEmpty)
+        #expect(firstCache.get(url) != nil)
+        #expect(secondCache.get(url) == nil)
+
+        _ = renderToBuffer(
+            image,
+            context: RenderContext(
+                availableWidth: 4,
+                availableHeight: 2,
+                tuiContext: secondContext,
+                identity: ViewIdentity(path: "image")
+            )
+        )
+        #expect(await waitForRequest(in: secondLoader))
+        #expect(firstLoader.requestedURLs == [url])
+        #expect(secondLoader.requestedURLs == [url])
+        #expect(secondCache.get(url) != nil)
+
+        firstContext.reset()
+        secondContext.reset()
+        #expect(firstCache.get(url) == nil)
+        #expect(secondCache.get(url) == nil)
+    }
+
     @Test("Render context receives the complete owning runtime")
     func renderContextReceivesCompleteOwningRuntime() {
         let storageBackend = VolatileStorageBackend()
@@ -271,6 +324,7 @@ struct TUIContextTests {
         #expect(renderContext.environment.appearanceManager === tuiContext.appearanceManager)
         #expect(renderContext.environment.statusBar === tuiContext.statusBar)
         #expect(renderContext.environment.appHeader === tuiContext.appHeader)
+        #expect(renderContext.environment.imageCache === tuiContext.imageCache)
         let environmentStorage = renderContext.environment.storageBackend as? VolatileStorageBackend
         #expect(environmentStorage === storageBackend)
         #expect(renderContext.environment.runtimeClock.now() == 42)
@@ -293,4 +347,51 @@ private struct RuntimeObservationView: View {
     var body: some View {
         Text("value:\(model.value)")
     }
+}
+
+private final class RecordingRuntimeImageLoader: ImageLoader, @unchecked Sendable {
+    private let lock = NSLock()
+    private var urls: [String] = []
+    private let image = RGBAImage(
+        width: 1,
+        height: 1,
+        pixels: [RGBA(r: 255, g: 255, b: 255)]
+    )
+
+    var requestedURLs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return urls
+    }
+
+    func loadImage(from path: String) throws -> RGBAImage {
+        image
+    }
+
+    func loadImage(from data: Data) throws -> RGBAImage {
+        image
+    }
+
+    func loadImage(
+        from urlString: String,
+        cache: URLImageCache,
+        timeout: TimeInterval,
+        maxPixelCount: Int?
+    ) throws -> RGBAImage {
+        cache.set(urlString, image: image)
+        lock.lock()
+        urls.append(urlString)
+        lock.unlock()
+        return image
+    }
+}
+
+private func waitForRequest(in loader: RecordingRuntimeImageLoader) async -> Bool {
+    for _ in 0..<1_000 {
+        if !loader.requestedURLs.isEmpty {
+            return true
+        }
+        await Task.yield()
+    }
+    return false
 }

--- a/Tests/TUIkitTests/ViewRendererTests.swift
+++ b/Tests/TUIkitTests/ViewRendererTests.swift
@@ -43,6 +43,58 @@ struct ViewRendererTests {
         #expect(terminal.outputContains("Abbrechen"))
     }
 
+    @Test("Two runtimes render alternately without sharing state or services")
+    func twoRuntimesRenderAlternatelyWithoutSharingStateOrServices() {
+        let firstTerminal = MockTerminal()
+        let secondTerminal = MockTerminal()
+        let firstContext = TUIContext()
+        let secondContext = TUIContext()
+        firstContext.localizationService.setLanguage(.german)
+        secondContext.localizationService.setLanguage(.french)
+        firstContext.storageBackend.setValue("first", forKey: "alternating-runtime-name")
+        secondContext.storageBackend.setValue("second", forKey: "alternating-runtime-name")
+        firstContext.notificationService.post("first notification")
+        secondContext.notificationService.post("second notification")
+        firstContext.paletteManager.cycleNext()
+        firstContext.focusManager.register(MockFocusable(id: "first-focus"))
+
+        let firstRenderer = ViewRenderer(terminal: firstTerminal, tuiContext: firstContext)
+        let secondRenderer = ViewRenderer(terminal: secondTerminal, tuiContext: secondContext)
+
+        firstRenderer.render { AlternatingRuntimeView() }
+        secondRenderer.render { AlternatingRuntimeView() }
+
+        #expect(firstTerminal.outputContains("first:0:Abbrechen"))
+        #expect(secondTerminal.outputContains("second:0:Annuler"))
+        #expect(firstContext.notificationService.activeEntries().map(\.message) == ["first notification"])
+        #expect(secondContext.notificationService.activeEntries().map(\.message) == ["second notification"])
+        #expect(firstContext.paletteManager.current.id != secondContext.paletteManager.current.id)
+        #expect(firstContext.focusManager.currentFocusedID == "first-focus")
+        #expect(secondContext.focusManager.currentFocusedID == nil)
+
+        let stateKey = StateStorage.StateKey(
+            identity: ViewIdentity(rootType: AlternatingRuntimeView.self),
+            propertyIndex: 0
+        )
+        let firstState: StateBox<Int> = firstContext.stateStorage.storage(for: stateKey, default: -1)
+        firstContext.appState.didRender()
+        secondContext.appState.didRender()
+        firstState.value = 9
+
+        #expect(firstContext.appState.needsRender)
+        #expect(secondContext.appState.needsRender == false)
+
+        secondTerminal.reset()
+        secondRenderer.render { AlternatingRuntimeView() }
+        firstTerminal.reset()
+        firstRenderer.render { AlternatingRuntimeView() }
+
+        #expect(secondTerminal.outputContains("second:0:Annuler"))
+        #expect(firstTerminal.outputContains("first:9:Abbrechen"))
+        #expect(firstContext.renderCache.stats.subtreeClears == 1)
+        #expect(secondContext.renderCache.stats.subtreeClears == 0)
+    }
+
     @Test("App rendering accepts an injected terminal session")
     func appRenderingAcceptsInjectedTerminalSession() {
         let terminal = MockTerminal()
@@ -77,6 +129,17 @@ private struct RendererPropertyWrapperView: View {
         VStack {
             Text("\(name):\(value)")
         }
+    }
+}
+
+private struct AlternatingRuntimeView: View {
+    @State private var value = 0
+    @AppStorage("alternating-runtime-name") private var name = "fallback"
+    @Environment(\.localizationService) private var localization
+
+    var body: some View {
+        Text("\(name):\(value):\(localization.string(for: LocalizationKey.Button.cancel))")
+            .equatable()
     }
 }
 

--- a/Tests/TUIkitTests/ViewRendererTests.swift
+++ b/Tests/TUIkitTests/ViewRendererTests.swift
@@ -5,6 +5,7 @@
 //  License: MIT
 
 import Testing
+import TUIkitTestSupport
 
 @testable import TUIkit
 
@@ -138,6 +139,31 @@ struct ViewRendererTests {
         #expect(terminal.outputContains("owned:7"))
         #expect(terminal.isRawModeEnabled == false)
         #expect(terminal.isInAlternateScreen == false)
+    }
+
+    @Test("Standalone shutdown cancels runtime tasks", .timeLimit(.minutes(1)))
+    func standaloneShutdownCancelsRuntimeTasks() async {
+        let started = AsyncSignal()
+        let release = AsyncSignal()
+        let completed = AsyncSignal()
+        let cancellationStates = TraceRecorder<Bool>()
+        let tuiContext = TUIContext()
+        let renderer = ViewRenderer(terminal: MockTerminal(), tuiContext: tuiContext)
+
+        renderer.render {
+            Text("Task").task {
+                started.signal()
+                await release.wait()
+                cancellationStates.record(Task.isCancelled)
+                completed.signal()
+            }
+        }
+
+        await started.wait()
+        renderer.shutdown()
+        release.signal()
+        await completed.wait()
+        #expect(cancellationStates.snapshot() == [true])
     }
 }
 

--- a/Tests/TUIkitTests/ViewRendererTests.swift
+++ b/Tests/TUIkitTests/ViewRendererTests.swift
@@ -1,0 +1,92 @@
+//  🖥️ TUIKit — Terminal UI Kit for Swift
+//  ViewRendererTests.swift
+//
+//  Created by LAYERED.work
+//  License: MIT
+
+import Testing
+
+@testable import TUIkit
+
+@MainActor
+@Suite("ViewRenderer Tests", .serialized)
+struct ViewRendererTests {
+    @Test("Standalone rendering supports composite views and property wrappers")
+    func standaloneRenderingSupportsCompositeViewsAndPropertyWrappers() {
+        let terminal = MockTerminal()
+        terminal.size = (40, 6)
+        let tuiContext = TUIContext()
+        tuiContext.storageBackend.setValue("owned", forKey: "renderer-name")
+        let renderer = ViewRenderer(terminal: terminal, tuiContext: tuiContext)
+
+        renderer.render {
+            RendererPropertyWrapperView()
+        }
+
+        #expect(terminal.outputContains("owned:7"))
+        #expect(tuiContext.stateStorage.count == 1)
+        #expect(terminal.isRawModeEnabled == false)
+        #expect(terminal.isInAlternateScreen == false)
+    }
+
+    @Test("Standalone builder receives the runtime environment")
+    func standaloneBuilderReceivesRuntimeEnvironment() {
+        let terminal = MockTerminal()
+        let tuiContext = TUIContext()
+        tuiContext.localizationService.setLanguage(.german)
+        let renderer = ViewRenderer(terminal: terminal, tuiContext: tuiContext)
+
+        renderer.render {
+            Text(localized: "button.cancel")
+        }
+
+        #expect(terminal.outputContains("Abbrechen"))
+    }
+
+    @Test("App rendering accepts an injected terminal session")
+    func appRenderingAcceptsInjectedTerminalSession() {
+        let terminal = MockTerminal()
+        terminal.size = (40, 6)
+        let tuiContext = TUIContext()
+        tuiContext.statusBar.showSystemItems = false
+        tuiContext.storageBackend.setValue("owned", forKey: "renderer-name")
+        let renderLoop = RenderLoop(
+            app: RendererTestApp(),
+            terminal: terminal,
+            statusBar: tuiContext.statusBar,
+            appHeader: tuiContext.appHeader,
+            focusManager: tuiContext.focusManager,
+            paletteManager: tuiContext.paletteManager,
+            appearanceManager: tuiContext.appearanceManager,
+            tuiContext: tuiContext
+        )
+
+        renderLoop.render()
+
+        #expect(terminal.outputContains("owned:7"))
+        #expect(terminal.isRawModeEnabled == false)
+        #expect(terminal.isInAlternateScreen == false)
+    }
+}
+
+private struct RendererPropertyWrapperView: View {
+    @State private var value = 7
+    @AppStorage("renderer-name") private var name = "fallback"
+
+    var body: some View {
+        VStack {
+            Text("\(name):\(value)")
+        }
+    }
+}
+
+@MainActor
+private struct RendererTestApp: App {
+    init() {}
+
+    var body: some Scene {
+        WindowGroup {
+            RendererPropertyWrapperView()
+        }
+    }
+}

--- a/Tests/TUIkitTests/ViewRendererTests.swift
+++ b/Tests/TUIkitTests/ViewRendererTests.swift
@@ -43,6 +43,26 @@ struct ViewRendererTests {
         #expect(terminal.outputContains("Abbrechen"))
     }
 
+    @Test("AppStorage projection reads from the owning runtime")
+    func appStorageProjectionReadsFromOwningRuntime() throws {
+        let terminal = MockTerminal()
+        let tuiContext = TUIContext()
+        tuiContext.storageBackend.setValue(true, forKey: "renderer-projection")
+        let renderer = ViewRenderer(terminal: terminal, tuiContext: tuiContext)
+
+        renderer.render {
+            RendererAppStorageProjectionView()
+        }
+
+        try #require(terminal.allOutput.stripped.contains("[x] Projection"))
+
+        tuiContext.appState.didRender()
+        #expect(tuiContext.focusManager.dispatchKeyEvent(KeyEvent(key: .space)))
+        let storedValue: Bool? = tuiContext.storageBackend.value(forKey: "renderer-projection")
+        #expect(storedValue == false)
+        #expect(tuiContext.appState.needsRender)
+    }
+
     @Test("Two runtimes render alternately without sharing state or services")
     func twoRuntimesRenderAlternatelyWithoutSharingStateOrServices() {
         let firstTerminal = MockTerminal()
@@ -140,6 +160,14 @@ private struct AlternatingRuntimeView: View {
     var body: some View {
         Text("\(name):\(value):\(localization.string(for: LocalizationKey.Button.cancel))")
             .equatable()
+    }
+}
+
+private struct RendererAppStorageProjectionView: View {
+    @AppStorage("renderer-projection") private var isEnabled = false
+
+    var body: some View {
+        Toggle("Projection", isOn: $isEnabled)
     }
 }
 


### PR DESCRIPTION
## Summary

- make `TUIContext` the per-app owner of render state, caches, services, storage, focus, themes, and image dependencies
- route state and service invalidation to the owning runtime, including projected `@AppStorage` bindings
- complete the standalone `renderOnce` runtime and cancel its lifecycle tasks on shutdown
- add alternating-runtime, standalone-rendering, focus, storage, image, and migration coverage

## Validation

- `DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer ./scripts/test-linux.sh macos`
- `./scripts/test-linux.sh linux`
- both gates: Swift 6.0.3, SwiftLint 0 violations in 365 files, 188 API compatibility tests, versioned consumer build, DocC, and 1225 tests
- three existing characterization issues remain explicitly known: #10, #12, and #14

Closes #8