### PR TITLE
Fix: Stabilize Linux API compatibility subprocesses

### DIFF
--- a/Tests/TUIkitTests/TUIContextTests.swift
+++ b/Tests/TUIkitTests/TUIContextTests.swift
@@ -7,6 +7,7 @@
 import Foundation
 import Observation
 import Testing
+import TUIkitTestSupport
 
 @testable import TUIkit
 
@@ -246,7 +247,7 @@ struct TUIContextTests {
         #expect(secondContext.appState.needsRender)
     }
 
-    @Test("Image requests and caches are isolated per runtime")
+    @Test("Image requests and caches are isolated per runtime", .timeLimit(.minutes(1)))
     func imageRequestsAndCachesAreIsolatedPerRuntime() async {
         let firstLoader = RecordingRuntimeImageLoader()
         let secondLoader = RecordingRuntimeImageLoader()
@@ -272,7 +273,7 @@ struct TUIContextTests {
                 identity: ViewIdentity(path: "image")
             )
         )
-        #expect(await waitForRequest(in: firstLoader))
+        await firstLoader.waitForRequest()
         #expect(firstLoader.requestedURLs == [url])
         #expect(secondLoader.requestedURLs.isEmpty)
         #expect(firstCache.get(url) != nil)
@@ -287,7 +288,7 @@ struct TUIContextTests {
                 identity: ViewIdentity(path: "image")
             )
         )
-        #expect(await waitForRequest(in: secondLoader))
+        await secondLoader.waitForRequest()
         #expect(firstLoader.requestedURLs == [url])
         #expect(secondLoader.requestedURLs == [url])
         #expect(secondCache.get(url) != nil)
@@ -351,6 +352,7 @@ private struct RuntimeObservationView: View {
 
 private final class RecordingRuntimeImageLoader: ImageLoader, @unchecked Sendable {
     private let lock = NSLock()
+    private let requestRecorded = AsyncSignal()
     private var urls: [String] = []
     private let image = RGBAImage(
         width: 1,
@@ -362,6 +364,10 @@ private final class RecordingRuntimeImageLoader: ImageLoader, @unchecked Sendabl
         lock.lock()
         defer { lock.unlock() }
         return urls
+    }
+
+    func waitForRequest() async {
+        await requestRecorded.wait()
     }
 
     func loadImage(from path: String) throws -> RGBAImage {
@@ -382,16 +388,7 @@ private final class RecordingRuntimeImageLoader: ImageLoader, @unchecked Sendabl
         lock.lock()
         urls.append(urlString)
         lock.unlock()
+        requestRecorded.signal()
         return image
     }
-}
-
-private func waitForRequest(in loader: RecordingRuntimeImageLoader) async -> Bool {
-    for _ in 0..<1_000 {
-        if !loader.requestedURLs.isEmpty {
-            return true
-        }
-        await Task.yield()
-    }
-    return false
 }

--- a/Tools/APICompatibility/Sources/APICompatibilityKit/CommandRunner+Contracts.swift
+++ b/Tools/APICompatibility/Sources/APICompatibilityKit/CommandRunner+Contracts.swift
@@ -69,7 +69,7 @@ extension CommandRunner {
             noun: "Clang module path"
         )
         let executions = try CompileContractRunner(
-            compilerProcess: FoundationSwiftCompilerProcess(),
+            compilerProcess: POSIXSwiftCompilerProcess(),
             compilerExecutable: compiler,
             compilerArguments: ["-I", swiftModules.path, "-I", clangModules.path]
         ).runCompileContracts(in: registry, fixturesDirectory: fixtures)

--- a/Tools/APICompatibility/Sources/APICompatibilityKit/CompileContractRunner.swift
+++ b/Tools/APICompatibility/Sources/APICompatibilityKit/CompileContractRunner.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
-
 public struct SwiftCompilerProcessResult: Equatable, Sendable {
     public let exitCode: Int32
     public let standardOutput: String
@@ -22,61 +16,40 @@ public protocol SwiftCompilerProcess: Sendable {
     func run(executable: URL, arguments: [String]) throws -> SwiftCompilerProcessResult
 }
 
-public struct FoundationSwiftCompilerProcess: SwiftCompilerProcess {
+public struct POSIXSwiftCompilerProcess: SwiftCompilerProcess {
     public init() {}
 
     public func run(executable: URL, arguments: [String]) throws -> SwiftCompilerProcessResult {
-        let fileManager = FileManager.default
-        let outputDirectory = fileManager.temporaryDirectory.appendingPathComponent(
-            "TUIkitAPICheck-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        let standardOutputURL = outputDirectory.appendingPathComponent("stdout")
-        let standardErrorURL = outputDirectory.appendingPathComponent("stderr")
+        let result: POSIXSubprocessResult
         do {
-            try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
-            try Data().write(to: standardOutputURL)
-            try Data().write(to: standardErrorURL)
-        } catch {
-            throw contractDiagnostic("compile-contract.process-output", "Unable to prepare Swift compiler output capture")
-        }
-        defer { try? fileManager.removeItem(at: outputDirectory) }
-
-        let standardOutputDescriptor = openOutputFile(at: standardOutputURL)
-        guard standardOutputDescriptor >= 0 else {
-            throw contractDiagnostic("compile-contract.process-output", "Unable to prepare Swift compiler output capture")
-        }
-        defer { close(standardOutputDescriptor) }
-        let standardErrorDescriptor = openOutputFile(at: standardErrorURL)
-        guard standardErrorDescriptor >= 0 else {
-            throw contractDiagnostic("compile-contract.process-output", "Unable to prepare Swift compiler output capture")
-        }
-        defer { close(standardErrorDescriptor) }
-
-        let exitCode = try runCompilerProcess(
-            executable: executable,
-            arguments: arguments,
-            standardOutputDescriptor: standardOutputDescriptor,
-            standardErrorDescriptor: standardErrorDescriptor
-        )
-
-        do {
-            let standardOutputData = try Data(contentsOf: standardOutputURL)
-            let standardErrorData = try Data(contentsOf: standardErrorURL)
-            guard let standardOutput = String(data: standardOutputData, encoding: .utf8),
-                  let standardError = String(data: standardErrorData, encoding: .utf8) else {
-                throw contractDiagnostic("compile-contract.process-output", "Unable to read Swift compiler output")
-            }
-            return SwiftCompilerProcessResult(
-                exitCode: exitCode,
-                standardOutput: standardOutput,
-                standardError: standardError
+            result = try POSIXSubprocessRunner().run(
+                executable: executable,
+                arguments: arguments
             )
+        } catch POSIXSubprocessError.outputCaptureSetup {
+            throw contractDiagnostic(
+                "compile-contract.process-output",
+                "Unable to prepare Swift compiler output capture"
+            )
+        } catch POSIXSubprocessError.outputCaptureRead {
+            throw contractDiagnostic("compile-contract.process-output", "Unable to read Swift compiler output")
         } catch {
+            throw contractDiagnostic("compile-contract.process-launch", "Unable to run the Swift compiler process")
+        }
+
+        guard let standardOutput = String(data: result.standardOutput, encoding: .utf8),
+              let standardError = String(data: result.standardError, encoding: .utf8) else {
             throw contractDiagnostic("compile-contract.process-output", "Unable to read Swift compiler output")
         }
+        return SwiftCompilerProcessResult(
+            exitCode: result.exitCode,
+            standardOutput: standardOutput,
+            standardError: standardError
+        )
     }
 }
+
+public typealias FoundationSwiftCompilerProcess = POSIXSwiftCompilerProcess
 
 public struct CompileContractExecution: Equatable, Sendable {
     public let contractID: String
@@ -232,121 +205,6 @@ private extension Array where Element == APICheckDiagnostic {
 
 private func contractDiagnostic(_ code: String, _ message: String) -> APICheckDiagnostic {
     APICheckDiagnostic(code: code, message: message)
-}
-
-private func openOutputFile(at url: URL) -> Int32 {
-    url.path.withCString { path in
-        open(path, O_WRONLY | O_TRUNC)
-    }
-}
-
-private func runCompilerProcess(
-    executable: URL,
-    arguments: [String],
-    standardOutputDescriptor: Int32,
-    standardErrorDescriptor: Int32
-) throws -> Int32 {
-    #if canImport(Darwin)
-    var fileActions: posix_spawn_file_actions_t?
-    #elseif canImport(Glibc)
-    var fileActions = posix_spawn_file_actions_t()
-    #endif
-    guard posix_spawn_file_actions_init(&fileActions) == 0 else {
-        throw processLaunchDiagnostic()
-    }
-    defer { posix_spawn_file_actions_destroy(&fileActions) }
-
-    guard posix_spawn_file_actions_adddup2(
-        &fileActions,
-        standardOutputDescriptor,
-        STDOUT_FILENO
-    ) == 0,
-    posix_spawn_file_actions_adddup2(
-        &fileActions,
-        standardErrorDescriptor,
-        STDERR_FILENO
-    ) == 0 else {
-        throw contractDiagnostic("compile-contract.process-output", "Unable to prepare Swift compiler output capture")
-    }
-    if standardOutputDescriptor != STDOUT_FILENO {
-        guard posix_spawn_file_actions_addclose(&fileActions, standardOutputDescriptor) == 0 else {
-            throw processLaunchDiagnostic()
-        }
-    }
-    if standardErrorDescriptor != STDERR_FILENO {
-        guard posix_spawn_file_actions_addclose(&fileActions, standardErrorDescriptor) == 0 else {
-            throw processLaunchDiagnostic()
-        }
-    }
-
-    let environment = ProcessInfo.processInfo.environment
-        .map { "\($0.key)=\($0.value)" }
-        .sorted()
-    var processID = pid_t()
-    let spawnStatus = try withMutableCStringArray([executable.path] + arguments) { argumentVector in
-        try withMutableCStringArray(environment) { environmentVector in
-            executable.path.withCString { executablePath in
-                posix_spawn(
-                    &processID,
-                    executablePath,
-                    &fileActions,
-                    nil,
-                    argumentVector,
-                    environmentVector
-                )
-            }
-        }
-    }
-    guard spawnStatus == 0 else {
-        throw processLaunchDiagnostic()
-    }
-
-    var processStatus = Int32()
-    while true {
-        let waitResult = waitpid(processID, &processStatus, 0)
-        if waitResult == processID {
-            return processExitCode(from: processStatus)
-        }
-        if waitResult == -1, errno == EINTR {
-            continue
-        }
-        throw processLaunchDiagnostic()
-    }
-}
-
-private func withMutableCStringArray<Result>(
-    _ strings: [String],
-    body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> Result
-) throws -> Result {
-    var pointers: [UnsafeMutablePointer<CChar>?] = []
-    pointers.reserveCapacity(strings.count + 1)
-    for string in strings {
-        guard let pointer = strdup(string) else {
-            throw processLaunchDiagnostic()
-        }
-        pointers.append(pointer)
-    }
-    defer {
-        for pointer in pointers {
-            free(pointer)
-        }
-    }
-    pointers.append(nil)
-    return try pointers.withUnsafeMutableBufferPointer { buffer in
-        guard let baseAddress = buffer.baseAddress else {
-            throw processLaunchDiagnostic()
-        }
-        return try body(baseAddress)
-    }
-}
-
-private func processExitCode(from status: Int32) -> Int32 {
-    let signal = status & 0x7F
-    return signal == 0 ? (status >> 8) & 0xFF : signal
-}
-
-private func processLaunchDiagnostic() -> APICheckDiagnostic {
-    contractDiagnostic("compile-contract.process-launch", "Unable to run the Swift compiler process")
 }
 
 private extension CompileContractRunner {

--- a/Tools/APICompatibility/Sources/APICompatibilityKit/POSIXSubprocessRunner.swift
+++ b/Tools/APICompatibility/Sources/APICompatibilityKit/POSIXSubprocessRunner.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+struct POSIXSubprocessResult: Equatable, Sendable {
+    let exitCode: Int32
+    let standardOutput: Data
+    let standardError: Data
+}
+
+enum POSIXSubprocessError: Error {
+    case launch
+    case outputCaptureRead
+    case outputCaptureSetup
+}
+
+struct POSIXSubprocessRunner: Sendable {
+    func run(executable: URL, arguments: [String]) throws -> POSIXSubprocessResult {
+        let fileManager = FileManager.default
+        let captureDirectory = fileManager.temporaryDirectory.appendingPathComponent(
+            "TUIkitAPICheck-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        do {
+            try fileManager.createDirectory(at: captureDirectory, withIntermediateDirectories: true)
+        } catch {
+            throw POSIXSubprocessError.outputCaptureSetup
+        }
+        defer { try? fileManager.removeItem(at: captureDirectory) }
+
+        let standardOutputURL = captureDirectory.appendingPathComponent("stdout")
+        let standardErrorURL = captureDirectory.appendingPathComponent("stderr")
+        let exitCode: Int32
+        do {
+            let standardOutputDescriptor = openOutputFile(at: standardOutputURL)
+            guard standardOutputDescriptor >= 0 else {
+                throw POSIXSubprocessError.outputCaptureSetup
+            }
+            defer { close(standardOutputDescriptor) }
+
+            let standardErrorDescriptor = openOutputFile(at: standardErrorURL)
+            guard standardErrorDescriptor >= 0 else {
+                throw POSIXSubprocessError.outputCaptureSetup
+            }
+            defer { close(standardErrorDescriptor) }
+
+            exitCode = try runProcess(
+                executable: executable,
+                arguments: arguments,
+                standardOutputDescriptor: standardOutputDescriptor,
+                standardErrorDescriptor: standardErrorDescriptor
+            )
+        }
+
+        do {
+            return try POSIXSubprocessResult(
+                exitCode: exitCode,
+                standardOutput: Data(contentsOf: standardOutputURL),
+                standardError: Data(contentsOf: standardErrorURL)
+            )
+        } catch {
+            throw POSIXSubprocessError.outputCaptureRead
+        }
+    }
+}
+
+private extension POSIXSubprocessRunner {
+    func openOutputFile(at url: URL) -> Int32 {
+        url.path.withCString { path in
+            open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)
+        }
+    }
+
+    func runProcess(
+        executable: URL,
+        arguments: [String],
+        standardOutputDescriptor: Int32,
+        standardErrorDescriptor: Int32
+    ) throws -> Int32 {
+        #if canImport(Darwin)
+        var fileActions: posix_spawn_file_actions_t?
+        #elseif canImport(Glibc)
+        var fileActions = posix_spawn_file_actions_t()
+        #endif
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            throw POSIXSubprocessError.launch
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        guard posix_spawn_file_actions_adddup2(
+            &fileActions,
+            standardOutputDescriptor,
+            STDOUT_FILENO
+        ) == 0,
+        posix_spawn_file_actions_adddup2(
+            &fileActions,
+            standardErrorDescriptor,
+            STDERR_FILENO
+        ) == 0 else {
+            throw POSIXSubprocessError.outputCaptureSetup
+        }
+        if standardOutputDescriptor != STDOUT_FILENO,
+           standardOutputDescriptor != STDERR_FILENO,
+           posix_spawn_file_actions_addclose(&fileActions, standardOutputDescriptor) != 0 {
+            throw POSIXSubprocessError.launch
+        }
+        if standardErrorDescriptor != STDOUT_FILENO,
+           standardErrorDescriptor != STDERR_FILENO,
+           posix_spawn_file_actions_addclose(&fileActions, standardErrorDescriptor) != 0 {
+            throw POSIXSubprocessError.launch
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+            .map { "\($0.key)=\($0.value)" }
+            .sorted()
+        var processID = pid_t()
+        let spawnStatus = try withMutableCStringArray([executable.path] + arguments) { argumentVector in
+            try withMutableCStringArray(environment) { environmentVector in
+                executable.path.withCString { executablePath in
+                    posix_spawn(
+                        &processID,
+                        executablePath,
+                        &fileActions,
+                        nil,
+                        argumentVector,
+                        environmentVector
+                    )
+                }
+            }
+        }
+        guard spawnStatus == 0 else {
+            throw POSIXSubprocessError.launch
+        }
+
+        return try waitForProcess(processID)
+    }
+
+    func withMutableCStringArray<Result>(
+        _ strings: [String],
+        body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> Result
+    ) throws -> Result {
+        var pointers: [UnsafeMutablePointer<CChar>?] = []
+        pointers.reserveCapacity(strings.count + 1)
+        for string in strings {
+            guard let pointer = strdup(string) else {
+                throw POSIXSubprocessError.launch
+            }
+            pointers.append(pointer)
+        }
+        defer {
+            for pointer in pointers {
+                free(pointer)
+            }
+        }
+        pointers.append(nil)
+        return try pointers.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                throw POSIXSubprocessError.launch
+            }
+            return try body(baseAddress)
+        }
+    }
+
+    func waitForProcess(_ processID: pid_t) throws -> Int32 {
+        var processStatus = Int32()
+        while true {
+            let waitResult = waitpid(processID, &processStatus, 0)
+            if waitResult == processID {
+                return processExitCode(from: processStatus)
+            }
+            if waitResult == -1, errno == EINTR {
+                continue
+            }
+            throw POSIXSubprocessError.launch
+        }
+    }
+
+    func processExitCode(from status: Int32) -> Int32 {
+        let signal = status & 0x7F
+        return signal == 0 ? (status >> 8) & 0xFF : signal
+    }
+}

--- a/Tools/APICompatibility/Sources/APICompatibilityKit/SymbolGraphExtractor.swift
+++ b/Tools/APICompatibility/Sources/APICompatibilityKit/SymbolGraphExtractor.swift
@@ -35,7 +35,7 @@ public struct SymbolGraphExtractor: Sendable {
     public init(executableURL: URL) {
         self.init(
             executableURL: executableURL,
-            processExecutor: FoundationSymbolGraphProcessExecutor()
+            processExecutor: POSIXSymbolGraphProcessExecutor()
         )
     }
 
@@ -206,42 +206,16 @@ protocol SymbolGraphProcessExecuting: Sendable {
     func execute(executableURL: URL, arguments: [String]) throws -> SymbolGraphProcessResult
 }
 
-private struct FoundationSymbolGraphProcessExecutor: SymbolGraphProcessExecuting {
+private struct POSIXSymbolGraphProcessExecutor: SymbolGraphProcessExecuting {
     func execute(executableURL: URL, arguments: [String]) throws -> SymbolGraphProcessResult {
-        let fileManager = FileManager.default
-        let captureDirectory = fileManager.temporaryDirectory.appendingPathComponent(
-            "TUIkitAPICheck-\(UUID().uuidString)",
-            isDirectory: true
+        let result = try POSIXSubprocessRunner().run(
+            executable: executableURL,
+            arguments: arguments
         )
-        try fileManager.createDirectory(at: captureDirectory, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: captureDirectory) }
-
-        let standardOutputURL = captureDirectory.appendingPathComponent("stdout")
-        let standardErrorURL = captureDirectory.appendingPathComponent("stderr")
-        try Data().write(to: standardOutputURL)
-        try Data().write(to: standardErrorURL)
-
-        let standardOutputHandle = try FileHandle(forWritingTo: standardOutputURL)
-        defer { try? standardOutputHandle.close() }
-        let standardErrorHandle = try FileHandle(forWritingTo: standardErrorURL)
-        defer { try? standardErrorHandle.close() }
-
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-        process.standardOutput = standardOutputHandle
-        process.standardError = standardErrorHandle
-        try process.run()
-        process.waitUntilExit()
-
-        try standardOutputHandle.close()
-        try standardErrorHandle.close()
-        let standardOutput = try Data(contentsOf: standardOutputURL)
-        let standardError = try Data(contentsOf: standardErrorURL)
         return SymbolGraphProcessResult(
-            exitCode: process.terminationStatus,
-            standardOutput: decode(standardOutput),
-            standardError: decode(standardError)
+            exitCode: result.exitCode,
+            standardOutput: decode(result.standardOutput),
+            standardError: decode(result.standardError)
         )
     }
 

--- a/Tools/APICompatibility/Tests/APICompatibilityKitTests/CompileContractTests.swift
+++ b/Tools/APICompatibility/Tests/APICompatibilityKitTests/CompileContractTests.swift
@@ -271,7 +271,7 @@ struct CompileContractTests {
     @Test("Real Swift compiler accepts the positive fixture and rejects the negative fixture")
     func realSwiftCompilerFixtures() throws {
         let runner = CompileContractRunner(
-            compilerProcess: FoundationSwiftCompilerProcess(),
+            compilerProcess: POSIXSwiftCompilerProcess(),
             compilerExecutable: URL(fileURLWithPath: "/usr/bin/env"),
             leadingArguments: ["swiftc"]
         )
@@ -298,7 +298,7 @@ struct CompileContractTests {
 
     @Test("Compiler process captures output and a nonzero exit status")
     func compilerProcessCapturesOutputAndExitStatus() throws {
-        let result = try FoundationSwiftCompilerProcess().run(
+        let result = try POSIXSwiftCompilerProcess().run(
             executable: URL(fileURLWithPath: "/bin/sh"),
             arguments: ["-c", "printf standard-output; printf standard-error >&2; exit 7"]
         )

--- a/Tools/APICompatibility/Tests/APICompatibilityKitTests/POSIXProcessClientTests.swift
+++ b/Tools/APICompatibility/Tests/APICompatibilityKitTests/POSIXProcessClientTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import APICompatibilityKit
+
+@Suite("POSIX process clients")
+struct POSIXProcessClientTests {
+    @Test("Compiler and symbol graph clients run concurrently through the shared runner")
+    func runsConcurrentProcessClients() async throws {
+        let rootDirectory = try FixtureSupport.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let executableURL = rootDirectory.appendingPathComponent("shared process tool")
+        try writeExecutable(to: executableURL)
+
+        let invocationCount = 24
+        let startGate = SubprocessStartGate(participantCount: invocationCount * 2)
+        let observations = try await withThrowingTaskGroup(
+            of: String.self,
+            returning: Set<String>.self
+        ) { group in
+            for index in 0..<invocationCount {
+                let outputDirectory = rootDirectory.appendingPathComponent(
+                    "Symbol Graph \(index)",
+                    isDirectory: true
+                )
+                try FileManager.default.createDirectory(
+                    at: outputDirectory,
+                    withIntermediateDirectories: true
+                )
+                group.addTask {
+                    await startGate.wait()
+                    let result = try POSIXSwiftCompilerProcess().run(
+                        executable: executableURL,
+                        arguments: ["--compiler-mode", "compiler \(index)"]
+                    )
+                    guard result.exitCode == 0, result.standardError.isEmpty else {
+                        throw ProcessClientTestError.unexpectedCompilerResult
+                    }
+                    return "compiler:\(result.standardOutput)"
+                }
+                group.addTask {
+                    await startGate.wait()
+                    let graphURL = try SymbolGraphExtractor(executableURL: executableURL).extract(
+                        SymbolGraphExtractionRequest(
+                            moduleName: "Fixture\(index)",
+                            targetTriple: "x86_64-unknown-linux-gnu",
+                            outputDirectory: outputDirectory
+                        )
+                    )
+                    return "graph:\(graphURL.lastPathComponent)"
+                }
+            }
+
+            var collected: Set<String> = []
+            for try await observation in group {
+                collected.insert(observation)
+            }
+            return collected
+        }
+
+        let expectedCompilerResults = (0..<invocationCount).map { "compiler:compiler \($0)" }
+        let expectedGraphResults = (0..<invocationCount).map { "graph:Fixture\($0).symbols.json" }
+        #expect(observations == Set(expectedCompilerResults + expectedGraphResults))
+    }
+}
+
+private extension POSIXProcessClientTests {
+    func writeExecutable(to executableURL: URL) throws {
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "--compiler-mode" ]; then
+            printf '%s' "$2"
+            exit 0
+        fi
+        module_name=
+        output_directory=
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -module-name)
+                    module_name="$2"
+                    shift 2
+                    ;;
+                -output-dir)
+                    output_directory="$2"
+                    shift 2
+                    ;;
+                -target|-sdk|-minimum-access-level)
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        : > "$output_directory/$module_name.symbols.json"
+        """
+        try Data(script.utf8).write(to: executableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executableURL.path
+        )
+    }
+}
+
+private enum ProcessClientTestError: Error {
+    case unexpectedCompilerResult
+}

--- a/Tools/APICompatibility/Tests/APICompatibilityKitTests/POSIXSubprocessRunnerTests.swift
+++ b/Tools/APICompatibility/Tests/APICompatibilityKitTests/POSIXSubprocessRunnerTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import APICompatibilityKit
+
+@Suite("POSIX subprocess runner")
+struct POSIXSubprocessRunnerTests {
+    @Test("Runs concurrent commands directly with isolated output")
+    func runsConcurrentCommandsDirectly() async throws {
+        let rootDirectory = try FixtureSupport.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectory) }
+        let executableURL = rootDirectory.appendingPathComponent("fake subprocess runner")
+        let markerURL = rootDirectory.appendingPathComponent("shell-evaluation-ran")
+        try writeExecutable(to: executableURL)
+
+        let invocationCount = 48
+        let startGate = SubprocessStartGate(participantCount: invocationCount)
+        let observations = try await withThrowingTaskGroup(
+            of: SubprocessObservation.self,
+            returning: [SubprocessObservation].self
+        ) { group in
+            for index in 0..<invocationCount {
+                group.addTask {
+                    await startGate.wait()
+                    let standardOutput = "stdout \(index) $(touch \(markerURL.path))"
+                    let standardError = "stderr \(index) with spaces"
+                    let result = try POSIXSubprocessRunner().run(
+                        executable: executableURL,
+                        arguments: [standardOutput, standardError, "7"]
+                    )
+                    return SubprocessObservation(
+                        result: result,
+                        expectedStandardOutput: standardOutput,
+                        expectedStandardError: standardError
+                    )
+                }
+            }
+
+            var collected: [SubprocessObservation] = []
+            for try await observation in group {
+                collected.append(observation)
+            }
+            return collected
+        }
+
+        #expect(observations.count == invocationCount)
+        for observation in observations {
+            #expect(observation.result.exitCode == 7)
+            #expect(observation.result.standardOutput == Data(observation.expectedStandardOutput.utf8))
+            #expect(observation.result.standardError == Data(observation.expectedStandardError.utf8))
+        }
+        #expect(!FileManager.default.fileExists(atPath: markerURL.path))
+    }
+}
+
+private extension POSIXSubprocessRunnerTests {
+    func writeExecutable(to executableURL: URL) throws {
+        let script = """
+        #!/bin/sh
+        printf '%s' "$1"
+        printf '%s' "$2" >&2
+        exit "$3"
+        """
+        try Data(script.utf8).write(to: executableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executableURL.path
+        )
+    }
+}
+
+private struct SubprocessObservation: Sendable {
+    let result: POSIXSubprocessResult
+    let expectedStandardOutput: String
+    let expectedStandardError: String
+}
+
+actor SubprocessStartGate {
+    private let participantCount: Int
+    private var arrivals = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(participantCount: Int) {
+        self.participantCount = participantCount
+    }
+
+    func wait() async {
+        arrivals += 1
+        guard arrivals < participantCount else {
+            let waitersToResume = waiters
+            waiters.removeAll()
+            for waiter in waitersToResume {
+                waiter.resume()
+            }
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #48.

APICompatibilityKit now uses one reusable POSIX subprocess runner for compile contracts and symbol graph extraction. It launches executables with direct argv handling, preserves the environment, captures stdout and stderr in isolated files, and reports exact exit status without shell evaluation or retries.

The Linux flake came from the remaining `Foundation.Process` symbol graph path running alongside the POSIX compiler path under the parallel test suite. This PR removes that mixed execution model while retaining `FoundationSwiftCompilerProcess` as a source-compatible alias.

Concurrent real-process tests cover both clients, executable paths and arguments with spaces, output isolation, nonzero exits, and shell-like argument contents.

## CI recovery

The first PR run passed Linux and SwiftUI snapshots but exposed an unrelated scheduler-sensitive wait in `TUIContextTests`. The existing runtime-isolation assertions are unchanged; their `Task.yield()` polling now uses the shared buffered async test signal. The focused test passed 50 consecutive macOS runs.

## Checklist

- [x] **Swift 6.0 compatible** (verified with Swift 6.0.3)
- [x] **Builds on macOS and Linux**
- [x] **All tests pass**
- [x] **No new SwiftLint warnings**
- [x] Public SwiftUI APIs are unchanged
- [x] View modifiers are unchanged

## Test Plan

- macOS deterministic quality gate with Xcode 16.2: 1225 SDK tests, 200 APICompatibility tests, compile contracts, consumer gate, DocC, and 0 SwiftLint violations.
- Pinned Swift 6.0.3 Linux container: 200 APICompatibility tests plus 30 repeated subprocess stress runs.
- Linux quality-gate components: lint, builds, compile contracts, consumer verification, 1225 SDK tests, contract validation, test discovery, and DocC all passed. The unfinished portion was rerun with `--jobs 1` after the local amd64 emulation corrupted SwiftPM parseable-output JSON during parallel compilation.
- Focused macOS runtime-image isolation test: 50 consecutive passes; changed-file SwiftLint clean.
